### PR TITLE
Properly close database when shutting down

### DIFF
--- a/db_service.py
+++ b/db_service.py
@@ -4,20 +4,18 @@ from aiosqlite import connect
 
 
 class DBService:
-    async def __del__(self):
-        await self.conn.close()
 
     @classmethod
     async def create(cls, config):
         self = DBService()
-        self.conn = await connect('configs/QuoteBot.db', detect_types=PARSE_DECLTYPES | PARSE_COLNAMES)
-        self.c = await self.conn.cursor()
+        self.con = await connect('configs/QuoteBot.db', detect_types=PARSE_DECLTYPES | PARSE_COLNAMES)
+        self.cur = await self.con.cursor()
 
-        result = await (await self.c.execute("PRAGMA auto_vacuum")).fetchone()
+        result = await (await self.cur.execute("PRAGMA auto_vacuum")).fetchone()
         if result[0] == 0:
-            await self.c.execute("PRAGMA auto_vacuum = 1")
+            await self.cur.execute("PRAGMA auto_vacuum = 1")
 
-        await self.c.execute("""
+        await self.cur.execute("""
             CREATE TABLE
             IF NOT EXISTS guild (
                 id INTEGER PRIMARY KEY,
@@ -27,7 +25,7 @@ class DBService:
                 pin_channel INTEGER
             )
         """.format(config['default_prefix'], config['default_lang']))
-        await self.c.execute("""
+        await self.cur.execute("""
             CREATE TABLE
             IF NOT EXISTS personal_quote (
                 id INTEGER PRIMARY KEY,
@@ -38,7 +36,10 @@ class DBService:
         return self
 
     async def execute(self, sql: str, *args):
-        return await self.c.execute(sql, *args)
+        return await self.cur.execute(sql, *args)
 
     async def commit(self):
-        return await self.conn.commit()
+        return await self.con.commit()
+
+    async def close(self):
+        return await self.con.close()

--- a/quote.py
+++ b/quote.py
@@ -62,6 +62,11 @@ class QuoteBot(commands.AutoShardedBot):
         if not message.author.bot:
             await self.process_commands(message)
 
+    async def close(self):
+        if db := getattr(self, 'db', False):
+            await db.close()
+        return await super().close()
+
 
 if __name__ == '__main__':
     with open(os.path.join('configs', 'credentials.json')) as json_data:


### PR DESCRIPTION
My old database implementation relied on the `DBService.__del__` method to close the connection after shutdown, but since `aiosqlite` is used now, `__del__` would have to be asynchronous which is not possible. As a result, the script keeps running after shutdown because the database connection is still open. In this solution, the connection will be closed when `QuoteBot.close` is called instead, which can still be done asynchronously.