### PR TITLE
Added Dutch localization, fixed intents and JSON encoding

### DIFF
--- a/localization/nl-NL.json
+++ b/localization/nl-NL.json
@@ -1,0 +1,11 @@
+{
+	"BOTLOG_guild_join": ":inbox_tray: **Server Toegevoegd** `{0}` (`{1}`)\n  Aantal server leden: {2}\n  Aantal servers: {3}",
+	"BOTLOG_guild_remove": ":outbox_tray: **Server Verwijderd** `{0}` (`{1}`)\n  Aantal server leden: {2}\n  Aantal servers: {3}",
+	"MAIN_quote_nomessage": "**Het bericht kon niet worden gevonden.**",
+	"MAIN_quote_nonsfw": "**Bericht geciteerd uit een NSFW kanaal.**",
+	"MAIN_quote_noperms": "**Ik heb geen machtiging om berichten uit dat kanaal op te halen.**",
+	"MAIN_quote_inputerror": "**Specificeer alstublieft een geldig bericht ID of URL.**",
+	"MAIN_quote_embedfooter": "Geciteerd door {0} uit #{1}",
+	"META_perms_noembed": "**Ik heb geen `Ingesloten links` machtiging.**",
+	"OWNER_shutdown": "**Afsluiten.**"
+}

--- a/quote.py
+++ b/quote.py
@@ -16,7 +16,7 @@ async def get_prefix(bot, msg):
 
 
 class QuoteBot(commands.AutoShardedBot):
-    def __init__(self, config, intents):
+    def __init__(self, config):
         super().__init__(help_command=None,
                          command_prefix=get_prefix,
                          case_insensitive=True,
@@ -24,14 +24,18 @@ class QuoteBot(commands.AutoShardedBot):
                          status=discord.Status.idle,
                          activity=discord.Game('starting up...'),
                          max_messages=config['max_message_cache'],
-                         intents=intents)
+                         intents=discord.Intents(guild_messages=True,
+                                                 guild_reactions=True,
+                                                 guilds=True,
+                                                 dm_messages=config['intents']['dm_messages'],
+                                                 members=config['intents']['members']))
 
         self.config = config
 
         self.responses = dict()
 
         for filename in os.listdir(path='localization'):
-            with open(os.path.join('localization', filename)) as json_data:
+            with open(os.path.join('localization', filename), encoding='utf-8') as json_data:
                 self.responses[filename[:-5]] = json.load(json_data)
 
     async def localize(self, guild, query):
@@ -72,13 +76,7 @@ class QuoteBot(commands.AutoShardedBot):
 if __name__ == '__main__':
     with open(os.path.join('configs', 'credentials.json')) as json_data:
         config = json.load(json_data)
-        intents = discord.Intents()
-        intents.guild_messages=True
-        intents.guild_reactions=True
-        intents.guilds=(True if config['botlog_webhook_url'] else False)
-        intents.dm_messages=config['intents']['dm_messages']
-        intents.members=config['intents']['members']
-        bot = QuoteBot(config, intents)
+        bot = QuoteBot(config)
 
     extensions = ['cogs.Main', 'cogs.OwnerOnly']
 


### PR DESCRIPTION
I added a Dutch localization and fixed errors regarding intents and JSON encoding. The `guilds` intent is required for `on_guild_join` to work and to access `Guild` objects from contexts, which is necessary regardless of the webhook configuration. The intents are now specified directly in `QuoteBot.__init__` so they no longer need to be passed as an argument. I also changed the encoding of the localization JSON files to UTF-8, which is necessary for some languages.