### PR TITLE
Fixed link quoting and optimized code for Python 3.8

### DIFF
--- a/cogs/Main.py
+++ b/cogs/Main.py
@@ -1,23 +1,29 @@
+import re
+
 import discord
 from discord.ext import commands
+
+MESSAGE_URL = re.compile(r"https?://((canary|ptb|www)\.)?discord(app)?\.com/channels/"
+                         r"(?P<guild_id>\d+)/(?P<channel_id>\d+)/"
+                         r"(?P<msg_id>\d+)")
 
 
 class Main(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
 
-    async def quote_embed(self, message, guild, channel, user):
-        embed = discord.Embed(description=message.content, color=message.author.color.value or discord.Embed.Empty, timestamp=message.created_at)
-        embed.set_author(name=str(message.author), icon_url=message.author.avatar_url)
-        if len(message.attachments) > 0:
-            if message.channel.is_nsfw() and not channel.is_nsfw():
-                embed.add_field(name='Attachment(s)', value=':underage: ' + await self.bot.localize(guild, 'MAIN_quote_nonsfw'))
-            elif len(message.attachments) == 1 and message.attachments[0].url.lower().endswith(('.jpg', '.jpeg', '.png', '.gif', '.gifv', '.webp', '.bmp')):
-                embed.set_image(url=message.attachments[0].url)
+    async def quote_embed(self, msg, guild, channel, user):
+        embed = discord.Embed(description=msg.content, color=msg.author.color.value or discord.Embed.Empty, timestamp=msg.created_at)
+        embed.set_author(name=str(msg.author), icon_url=msg.author.avatar_url)
+        if msg.attachments:
+            if msg.channel.is_nsfw() and not channel.is_nsfw():
+                embed.add_field(name='Attachment(s)', value=f":underage: {await self.bot.localize(guild, 'MAIN_quote_nonsfw')}")
+            elif len(msg.attachments) == 1 and (url := msg.attachments[0].url).lower().endswith(('.jpg', '.jpeg', '.png', '.gif', '.gifv', '.webp', '.bmp')):
+                embed.set_image(url=url)
             else:
-                embed.add_field(name='Attachment(s)', value='\n'.join('[' + attachment.filename + '](' + attachment.url + ')' for attachment in message.attachments))
+                embed.add_field(name='Attachment(s)', value='\n'.join(f'[{attachment.filename}]({attachment.url})' for attachment in msg.attachments))
         footer_text = await self.bot.localize(guild, 'MAIN_quote_embedfooter')
-        embed.set_footer(text=footer_text.format(str(user), message.channel.name))
+        embed.set_footer(text=footer_text.format(str(user), msg.channel.name))
         return embed
 
     @commands.Cog.listener()
@@ -38,62 +44,54 @@ class Main(commands.Cog):
             channel = guild.get_channel(payload.channel_id)
             perms = guild.me.permissions_in(channel)
             if payload.member.permissions_in(channel).send_messages and perms.read_message_history and perms.send_messages and perms.embed_links:
-                message = discord.utils.get(self.bot.cached_messages, channel=channel, id=payload.message_id)
-                if not message:
-                    message = await channel.fetch_message(payload.message_id)
-                await channel.send(embed=await self.quote_embed(message, guild, channel, payload.member))
+                if not (msg := discord.utils.get(self.bot.cached_messages, channel=channel, id=payload.message_id)):
+                    msg = await channel.fetch_message(payload.message_id)
+                await channel.send(embed=await self.quote_embed(msg, guild, channel, payload.member))
 
     @commands.command(aliases=['q'])
-    async def quote(self, ctx, msg):
+    async def quote(self, ctx, query: str):
         perms = ctx.guild.me.permissions_in(ctx.channel)
         if not perms.send_messages:
             return
         elif not perms.embed_links:
-            await ctx.send(content=self.bot.config['response_strings']['error'] + ' ' + await self.bot.localize(ctx.guild, 'META_perms_noembed'))
+            return await ctx.send(content=f"{self.bot.config['response_strings']['error']} {await self.bot.localize(ctx.guild, 'META_perms_noembed')}")
+        msg = None
+        try:
+            msg_id = int(query)
+        except ValueError:
+            if match := MESSAGE_URL.match(query.strip()):
+                guild_id, channel_id, msg_id = map(int, match.groups()[-3:])
+                if (guild := self.bot.get_guild(guild_id)) and (channel := guild.get_channel(channel_id)):
+                    perms = guild.me.permissions_in(channel)
+                    if perms.read_messages and perms.read_message_history:
+                        if not (msg := discord.utils.get(self.bot.cached_messages, channel__id=channel_id, id=msg_id)):
+                            try:
+                                msg = await channel.fetch_message(msg_id)
+                            except discord.NotFound:
+                                pass
+                    else:
+                        return await ctx.send(content=f"{self.bot.config['response_strings']['error']} {await self.bot.localize(ctx.guild, 'MAIN_quote_noperms')}")
+            else:
+                return await ctx.send(content=f"{self.bot.config['response_strings']['error']} {await self.bot.localize(ctx.guild, 'MAIN_quote_inputerror')}")
         else:
-            message = None
-            try:
-                msg_id = int(msg)
-            except ValueError:
+            if not (msg := discord.utils.get(self.bot.cached_messages, channel=ctx.channel, id=msg_id)) or (msg := discord.utils.get(self.bot.cached_messages, guild=ctx.guild, id=msg_id)):
                 try:
-                    list_ids = [int(i) for i in msg.strip('https://canary.discord.com/channels/').split('/')]
-                except ValueError:
-                    return await ctx.send(content=self.bot.config['response_strings']['error'] + ' ' + await self.bot.localize(ctx.guild, 'MAIN_quote_inputerror'))
-                else:
-                    guild = self.bot.get_guild(list_ids[0])
-                    channel = self.bot.get_channel(list_ids[1])
-                    if channel:
-                        perms = guild.me.permissions_in(channel)
-                        if perms.read_messages and perms.read_message_history:
-                            message = discord.utils.get(self.bot.cached_messages, channel__id=list_ids[1], id=list_ids[2])
-                            if not message:
-                                try:
-                                    message = await channel.fetch_message(list_ids[2])
-                                except discord.NotFound:
-                                    pass
-                        else:
-                            return await ctx.send(content=self.bot.config['response_strings']['error'] + ' ' + await self.bot.localize(ctx.guild, 'MAIN_quote_noperms'))
-            else:
-                message = discord.utils.get(self.bot.cached_messages, channel=ctx.channel, id=msg_id)
-                if not message:
-                    message = discord.utils.get(self.bot.cached_messages, guild=ctx.guild, id=msg_id)
-                    if not message:
-                        try:
-                            message = await ctx.channel.fetch_message(msg_id)
-                        except (discord.NotFound, discord.Forbidden):
-                            for channel in ctx.guild.text_channels:
-                                perms = ctx.guild.me.permissions_in(channel)
-                                if perms.read_messages and perms.read_message_history and channel != ctx.channel:
-                                    try:
-                                        message = await channel.fetch_message(msg_id)
-                                    except discord.NotFound:
-                                        continue
-                                    else:
-                                        break
-            if message:
-                await ctx.send(embed=await self.quote_embed(message, ctx.guild, ctx.channel, ctx.author))
-            else:
-                await ctx.send(content=self.bot.config['response_strings']['error'] + ' ' + await self.bot.localize(ctx.guild, 'MAIN_quote_nomessage'))
+                    msg = await ctx.channel.fetch_message(msg_id)
+                except (discord.NotFound, discord.Forbidden):
+                    for channel in ctx.guild.text_channels:
+                        perms = ctx.guild.me.permissions_in(channel)
+                        if perms.read_messages and perms.read_message_history and channel != ctx.channel:
+                            try:
+                                msg = await channel.fetch_message(msg_id)
+                            except discord.NotFound:
+                                continue
+                            else:
+                                break
+        if msg:
+            await ctx.send(embed=await self.quote_embed(msg, ctx.guild, ctx.channel, ctx.author))
+        else:
+            await ctx.send(content=f"{self.bot.config['response_strings']['error']} {await self.bot.localize(ctx.guild, 'MAIN_quote_nomessage')}")
+
 
 
 def setup(bot):

--- a/cogs/OwnerOnly.py
+++ b/cogs/OwnerOnly.py
@@ -9,7 +9,7 @@ class OwnerOnly(commands.Cog):
     @commands.command()
     async def shutdown(self, ctx):
         try:
-            await ctx.send(content=self.bot.config['response_strings']['success'] + ' ' + await self.bot.localize(ctx.guild, 'OWNER_shutdown'))
+            await ctx.send(content=f"{self.bot.config['response_strings']['success']} {await self.bot.localize(ctx.guild, 'OWNER_shutdown')}")
         except discord.Forbidden:
             pass
         await self.bot.close()


### PR DESCRIPTION
For link quoting to work correctly, `strip` has been replaced by regular expression matching to only match valid message URLs. Several parts of the code have been optimized for Python 3.8 by using f-strings for string formatting and walrus operators wherever possible. For clarity and consistency, I renamed `msg` to `query` in the `quote` command and `message` to `msg` everywhere.