### PR TITLE
Improve code formatting and quote efficiency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
+.vs/
+.vscode/
 __pycache__/
 configs/QuoteBot.db

--- a/cogs/Botlog.py
+++ b/cogs/Botlog.py
@@ -9,17 +9,25 @@ class Events(commands.Cog):
     async def on_guild_join(self, guild):
         if guild.id in await self.bot.fetch("SELECT id FROM blocked", one=False):
             return
-        await (bot := self.bot).webhook.send(username=bot.user.name,
-                                             avatar_url=bot.user.avatar_url,
-                                             content=f"{bot.config['response_strings']['guild_add']} {(await bot.localize(bot.webhook.guild, 'BOTLOG_guild_join')).format(guild.name.replace('`', '').replace('*', ''), guild.id, guild.member_count, len(bot.guilds))}")
+        await (bot := self.bot).webhook.send(
+            username=bot.user.name,
+            avatar_url=bot.user.avatar_url,
+            content=(await bot.localize(bot.webhook.guild, "BOTLOG_guild_join", "guild_add")).format(
+                guild.name.replace("`", "").replace("*", ""), guild.id, guild.member_count, len(bot.guilds)
+            ),
+        )
 
     @commands.Cog.listener()
     async def on_guild_remove(self, guild):
         if guild.id in await self.bot.fetch("SELECT id FROM blocked", one=False):
             return
-        await (bot := self.bot).webhook.send(username=bot.user.name,
-                                             avatar_url=bot.user.avatar_url,
-                                             content=f"{bot.config['response_strings']['guild_remove']} {(await bot.localize(bot.webhook.guild, 'BOTLOG_guild_remove')).format(guild.name.replace('`', '').replace('*', ''), guild.id, guild.member_count, len(bot.guilds))}")
+        await (bot := self.bot).webhook.send(
+            username=bot.user.name,
+            avatar_url=bot.user.avatar_url,
+            content=(await bot.localize(bot.webhook.guild, "BOTLOG_guild_remove", "guild_remove")).format(
+                guild.name.replace("`", "").replace("*", ""), guild.id, guild.member_count, len(bot.guilds)
+            ),
+        )
 
 
 def setup(bot):

--- a/cogs/Main.py
+++ b/cogs/Main.py
@@ -4,175 +4,209 @@ import re
 import discord
 from discord.ext import commands
 
-MARKDOWN = re.compile((r"```.*?```"                      # ```multiline code```
-                       r"|`.*?`"                         # `inline code`
-                       r"|^>\s.*?$"                      # > quote
-                       r"|\*\*\*(?!\s).*?(?<!\s)\*\*\*"  # ***bold italics***
-                       r"|\*\*(?!\s).*?(?<!\s)\*\*"      # **bold**
-                       r"|\*(?!\s).*?(?<!\s)\*"          # *italics*
-                       r"|__.*?__"                       # __underline__
-                       r"|~~.*?~~"                       # ~~strikethrough~~
-                       r"|\|\|.*?\|\|"                   # ||spoiler||
-                       r"|<https?://\S*?>"),             # <suppressed links>
-                      re.DOTALL | re.MULTILINE)
+MARKDOWN = re.compile(
+    (
+        r"```.*?```"  # ```multiline code```
+        r"|`.*?`"  # `inline code`
+        r"|^>\s.*?$"  # > quote
+        r"|\*\*\*(?!\s).*?(?<!\s)\*\*\*"  # ***bold italics***
+        r"|\*\*(?!\s).*?(?<!\s)\*\*"  # **bold**
+        r"|\*(?!\s).*?(?<!\s)\*"  # *italics*
+        r"|__.*?__"  # __underline__
+        r"|~~.*?~~"  # ~~strikethrough~~
+        r"|\|\|.*?\|\|"  # ||spoiler||
+        r"|<https?://\S*?>"
+    ),  # <suppressed links>
+    re.DOTALL | re.MULTILINE,
+)
+QUOTE_EXCEPTIONS = (discord.NotFound, discord.Forbidden, discord.HTTPException, commands.BadArgument)
 
 
 async def webhook_copy(webhook, msg, clean_content=False):
-    await webhook.send(username=getattr(msg.author, 'nick', False) or msg.author.name,
-                       avatar_url=msg.author.avatar_url,
-                       content=msg.clean_content if clean_content else msg.content,
-                       files=[await attachment.to_file() for attachment in msg.attachments],
-                       embed=(msg.embeds[0] if msg.embeds and msg.embeds[0].type == 'rich' else None),
-                       allowed_mentions=discord.AllowedMentions.none())
+    await webhook.send(
+        username=getattr(msg.author, "nick", False) or msg.author.name,
+        avatar_url=msg.author.avatar_url,
+        content=msg.clean_content if clean_content else msg.content,
+        files=[await attachment.to_file() for attachment in msg.attachments],
+        embed=(msg.embeds[0] if msg.embeds and msg.embeds[0].type == "rich" else None),
+        allowed_mentions=discord.AllowedMentions.none(),
+    )
 
 
 class Main(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
-        self.channel_converter = commands.TextChannelConverter()
         self.user_converter = commands.UserConverter()
 
     @commands.Cog.listener()
     async def on_message(self, msg):
-        if ((ctx := await self.bot.get_context(msg)).valid or msg.author.bot or not msg.guild
-                or not (await self.bot.fetch("SELECT quote_links FROM guild WHERE id = ?", (msg.guild.id,)))):
+        if (
+            (ctx := await self.bot.get_context(msg)).valid
+            or msg.author.bot
+            or not msg.guild
+            or not (await self.bot.fetch("SELECT quote_links FROM guild WHERE id = ?", (msg.guild.id,)))
+        ):
             return
-        if match := self.bot.msg_url_regex.search(MARKDOWN.sub('?', msg.content)):
+        if match := self.bot.msg_url_regex.search(MARKDOWN.sub("?", msg.content)):
             try:
                 quoted_msg = await self.bot.get_message(ctx, match.groupdict())
-            except Exception:
-                return
-            return await self.bot.quote_message(quoted_msg, msg.channel, msg.author, 'link')
+                await self.bot.quote_message(quoted_msg, msg.channel, msg.author, "link")
+            except QUOTE_EXCEPTIONS:
+                pass
 
     @commands.Cog.listener()
     async def on_raw_reaction_add(self, payload):
-        if payload.emoji.name != '💬' or not await self.bot.fetch("SELECT on_reaction FROM guild WHERE id = ?", (payload.guild_id,)):
+        if payload.emoji.name != "💬" or not await self.bot.fetch(
+            "SELECT on_reaction FROM guild WHERE id = ?", (payload.guild_id,)
+        ):
             return
         guild = self.bot.get_guild(payload.guild_id)
         channel = guild.get_channel(payload.channel_id)
         perms = guild.me.permissions_in(channel)
-        if payload.member.permissions_in(channel).send_messages and perms.read_message_history and perms.send_messages and perms.embed_links:
-            if not (msg := discord.utils.get(self.bot.cached_messages, channel=channel, id=payload.message_id)):
-                msg = await channel.fetch_message(payload.message_id)
-            await self.bot.quote_message(msg, channel, payload.member)
+        if (
+            payload.member.permissions_in(channel).send_messages
+            and perms.read_message_history
+            and perms.send_messages
+            and perms.embed_links
+        ):
+            try:
+                msg = channel._state._get_message(payload.message_id) or await channel.fetch_message(payload.message_id)
+                await self.bot.quote_message(msg, channel, payload.member)
+            except QUOTE_EXCEPTIONS:
+                pass
 
-    @commands.command(aliases=['q'])
+    @commands.command(aliases=["q"])
     async def quote(self, ctx, *, query: str = None):
         await ctx.trigger_typing()
         if guild := ctx.guild:
-            if (perms := guild.me.permissions_in(ctx.channel)).manage_messages and await self.bot.fetch("SELECT delete_commands FROM guild WHERE id = ?", (guild.id,)):
+            if (perms := guild.me.permissions_in(ctx.channel)).manage_messages and await self.bot.fetch(
+                "SELECT delete_commands FROM guild WHERE id = ?", (guild.id,)
+            ):
                 await ctx.message.delete()
             if not perms.send_messages:
                 return
-            elif not perms.embed_links:
-                return await ctx.send(f"{self.bot.config['response_strings']['error']} {await self.bot.localize(guild, 'META_perms_noembed')}")
+            if not perms.embed_links:
+                return await ctx.send(await self.bot.localize(guild, "META_perms_noembed", "error"))
         if query is None:
             try:
                 async for msg in ctx.channel.history(limit=1, before=ctx.message):
-                    return await self.bot.quote_message(msg, ctx.channel, ctx.author)
-            except Exception:
-                return await ctx.send(f"{self.bot.config['response_strings']['error']} {await self.bot.localize(guild, 'MAIN_quote_nomessage')}")
-        if match := self.bot.msg_id_regex.match(query) or self.bot.msg_url_regex.match(query):
+                    await self.bot.quote_message(msg, ctx.channel, ctx.author)
+            except QUOTE_EXCEPTIONS:
+                await ctx.send(await self.bot.localize(guild, "MAIN_quote_nomessage", "error"))
+        elif match := self.bot.msg_id_regex.match(query) or self.bot.msg_url_regex.match(query):
             try:
-                return await self.bot.quote_message(await self.bot.get_message(ctx, match.groupdict()), ctx.channel, ctx.author)
+                return await self.bot.quote_message(
+                    await self.bot.get_message(ctx, match.groupdict()), ctx.channel, ctx.author
+                )
             except discord.Forbidden:
-                return await ctx.send(f"{self.bot.config['response_strings']['error']} {await self.bot.localize(guild, 'MAIN_quote_noperms')}")
-            except Exception:
-                if match.group('channel_id'):
-                    return await ctx.send(f"{self.bot.config['response_strings']['error']} {await self.bot.localize(guild, 'MAIN_quote_nomessage')}")
-        try:
-            channel = await self.channel_converter.convert(ctx, query)
-        except Exception:
+                return await ctx.send(await self.bot.localize(guild, "MAIN_quote_noperms", "error"))
+            except (discord.NotFound, discord.HTTPException, commands.BadArgument):
+                if match.group("channel_id"):
+                    return await ctx.send(await self.bot.localize(guild, "MAIN_quote_nomessage", "error"))
             try:
                 user = await self.user_converter.convert(ctx, query)
-            except Exception:
-                if match:
-                    return await ctx.send(f"{self.bot.config['response_strings']['error']} {await self.bot.localize(guild, 'MAIN_quote_nomessage')}")
+            except QUOTE_EXCEPTIONS:
+                await ctx.send(await self.bot.localize(guild, "MAIN_quote_nomessage", "error"))
             else:
                 try:
                     async for msg in ctx.channel.history(before=ctx.message):
                         if msg.author.id == user.id:
                             return await self.bot.quote_message(msg, ctx.channel, ctx.author)
-                except Exception:
+                except QUOTE_EXCEPTIONS:
                     pass
-                return await ctx.send(f"{self.bot.config['response_strings']['error']} {await self.bot.localize(guild, 'MAIN_quote_nomessage')}")
+                await ctx.send(await self.bot.localize(guild, "MAIN_quote_nomessage", "error"))
         else:
-            try:
-                async for msg in channel.history(limit=1, before=ctx.message):
-                    return await self.bot.quote_message(msg, ctx.channel, ctx.author)
-            except discord.Forbidden:
-                return await ctx.send(f"{self.bot.config['response_strings']['error']} {await self.bot.localize(guild, 'MAIN_quote_noperms')}")
-            except Exception:
-                return await ctx.send(f"{self.bot.config['response_strings']['error']} {await self.bot.localize(guild, 'MAIN_quote_nomessage')}")
-        return await ctx.send(f"{self.bot.config['response_strings']['error']} {await self.bot.localize(guild, 'MAIN_quote_inputerror')}")
+            await ctx.send(await self.bot.localize(guild, "MAIN_quote_inputerror", "error"))
 
-    @commands.command(aliases=['langs', 'localizations'])
+    @commands.command(aliases=["langs", "localizations"])
     async def languages(self, ctx):
-        await ctx.send(embed=discord.Embed(title=f":map: {await self.bot.localize(guild := ctx.guild, 'MAIN_languages_title')}",
-                                           description='\n'.join(f':flag_{tag[3:].lower()}: **{tag}**' for tag in sorted(self.bot.responses.keys())),
-                                           color=(guild and guild.me.color.value) or self.bot.config['default_embed_color']))
+        await ctx.send(
+            embed=discord.Embed(
+                title=f":map: {await self.bot.localize(guild := ctx.guild, 'MAIN_languages_title')}",
+                description="\n".join(f":flag_{tag[3:].lower()}: **{tag}**" for tag in sorted(self.bot.responses.keys())),
+                color=(guild and guild.me.color.value) or self.bot.config["default_embed_color"],
+            )
+        )
 
-    @commands.command(aliases=['togglereactions', 'togglereact', 'reactions'])
+    @commands.command(aliases=["togglereactions", "togglereact", "reactions"])
     @commands.guild_only()
     @commands.has_permissions(manage_guild=True)
     async def togglereaction(self, ctx):
         async with self.bot.db_connect() as db:
-            new = int(not (await (await db.execute("SELECT on_reaction FROM guild WHERE id = ?", (ctx.guild.id,))).fetchone())[0])
+            new = int(
+                not (await (await db.execute("SELECT on_reaction FROM guild WHERE id = ?", (ctx.guild.id,))).fetchone())[0]
+            )
             await db.execute("UPDATE guild SET on_reaction = ? WHERE id = ?", (new, ctx.guild.id))
             await db.commit()
-        await ctx.send(f"{self.bot.config['response_strings']['success']} {await self.bot.localize(ctx.guild, 'MAIN_togglereaction_enabled' if new else 'MAIN_togglereaction_disabled')}")
+        await ctx.send(
+            await self.bot.localize(
+                ctx.guild, "MAIN_togglereaction_enabled" if new else "MAIN_togglereaction_disabled", "success"
+            )
+        )
 
-    @commands.command(aliases=['links'])
+    @commands.command(aliases=["links"])
     @commands.guild_only()
     @commands.has_permissions(manage_guild=True)
     async def togglelinks(self, ctx):
         async with self.bot.db_connect() as db:
-            new = int(not (await (await db.execute("SELECT quote_links FROM guild WHERE id = ?", (ctx.guild.id,))).fetchone())[0])
+            new = int(
+                not (await (await db.execute("SELECT quote_links FROM guild WHERE id = ?", (ctx.guild.id,))).fetchone())[0]
+            )
             await db.execute("UPDATE guild SET quote_links = ? WHERE id = ?", (new, ctx.guild.id))
             await db.commit()
-        await ctx.send(f"{self.bot.config['response_strings']['success']} {await self.bot.localize(ctx.guild, 'MAIN_togglelinks_enabled' if new else 'MAIN_togglelinks_disabled')}")
+        await ctx.send(
+            await self.bot.localize(ctx.guild, "MAIN_togglelinks_enabled" if new else "MAIN_togglelinks_disabled", "success")
+        )
 
-    @commands.command(aliases=['delcommands', 'delete'])
+    @commands.command(aliases=["delcommands", "delete"])
     @commands.guild_only()
     @commands.has_permissions(manage_guild=True)
     async def toggledelete(self, ctx):
         async with self.bot.db_connect() as db:
-            new = int(not (await (await db.execute("SELECT delete_commands FROM guild WHERE id = ?", (ctx.guild.id,))).fetchone())[0])
+            new = int(
+                not (await (await db.execute("SELECT delete_commands FROM guild WHERE id = ?", (ctx.guild.id,))).fetchone())[
+                    0
+                ]
+            )
             if new and not ctx.me.permissions_in(ctx.channel).manage_messages:
-                return await ctx.send(f"{self.bot.config['response_strings']['error']} {await self.bot.localize(ctx.guild, 'META_perms_nomanagemessages')}")
+                return await ctx.send(await self.bot.localize(ctx.guild, "META_perms_nomanagemessages", "error"))
             await db.execute("UPDATE guild SET delete_commands = ? WHERE id = ?", (new, ctx.guild.id))
             await db.commit()
-        await ctx.send(f"{self.bot.config['response_strings']['success']} {await self.bot.localize(ctx.guild, 'MAIN_toggledelete_enabled' if new else 'MAIN_toggledelete_disabled')}")
+        await ctx.send(
+            await self.bot.localize(
+                ctx.guild, "MAIN_toggledelete_enabled" if new else "MAIN_toggledelete_disabled", "success"
+            )
+        )
 
-    @commands.command(aliases=['prefix'])
+    @commands.command(aliases=["prefix"])
     @commands.guild_only()
     @commands.has_permissions(manage_guild=True)
     async def setprefix(self, ctx, prefix: str):
         if len(prefix) > 3:
-            return await ctx.send(f"{self.bot.config['response_strings']['error']} {await self.bot.localize(ctx.guild, 'MAIN_setprefix_toolong')}")
+            return await ctx.send(await self.bot.localize(ctx.guild, "MAIN_setprefix_toolong", "error"))
         async with self.bot.db_connect() as db:
-            await db.execute('UPDATE guild SET prefix = ? WHERE id = ?', (prefix, ctx.guild.id))
+            await db.execute("UPDATE guild SET prefix = ? WHERE id = ?", (prefix, ctx.guild.id))
             await db.commit()
-        await ctx.send(f"{self.bot.config['response_strings']['success']} {(await self.bot.localize(ctx.guild, 'MAIN_setprefix_set')).format(prefix)}")
+        await ctx.send((await self.bot.localize(ctx.guild, "MAIN_setprefix_set", "success")).format(prefix))
 
-    @commands.command(aliases=['language', 'setlang', 'lang', 'localize'])
+    @commands.command(aliases=["language", "setlang", "lang", "localize"])
     @commands.guild_only()
     @commands.has_permissions(manage_guild=True)
     async def setlanguage(self, ctx, language: str):
         if language not in self.bot.responses:
-            return await ctx.send(f"{self.bot.config['response_strings']['error']} {await self.bot.localize(ctx.guild, 'MAIN_setlanguage_notavailable')}")
+            return await ctx.send(await self.bot.localize(ctx.guild, "MAIN_setlanguage_notavailable", "error"))
         async with self.bot.db_connect() as db:
-            await db.execute('UPDATE guild SET language = ? WHERE id = ?', (language, ctx.guild.id))
+            await db.execute("UPDATE guild SET language = ? WHERE id = ?", (language, ctx.guild.id))
             await db.commit()
-        await ctx.send(f"{self.bot.config['response_strings']['success']} {(await self.bot.localize(ctx.guild, 'MAIN_setlanguage_set')).format(language)}")
+        await ctx.send((await self.bot.localize(ctx.guild, "MAIN_setlanguage_set", "success")).format(language))
 
     @commands.command()
     @commands.has_permissions(manage_guild=True)
     async def clone(self, ctx, msg_limit: int, channel: discord.TextChannel):
         if not ctx.guild.me.permissions_in(ctx.channel).manage_webhooks:
-            await ctx.send(f"{self.bot.config['response_strings']['error']} {await self.bot.localize(ctx.guild, 'META_perms_nowebhook')}")
+            await ctx.send(await self.bot.localize(ctx.guild, "META_perms_nowebhook", "error"))
         elif msg_limit < 1 or msg_limit > 50:
-            await ctx.send(f"{self.bot.config['response_strings']['error']} {await self.bot.localize(ctx.guild, 'MAIN_clone_msglimit')}")
+            await ctx.send(await self.bot.localize(ctx.guild, "MAIN_clone_msglimit", "error"))
         else:
             webhook = await ctx.channel.create_webhook(name=self.bot.user.name)
             messages = await channel.history(limit=msg_limit, before=ctx.message).flatten()

--- a/cogs/OwnerOnly.py
+++ b/cogs/OwnerOnly.py
@@ -9,38 +9,46 @@ class OwnerOnly(commands.Cog):
     async def cog_check(self, ctx):
         return await self.bot.is_owner(ctx.author)
 
-    @commands.command(aliases=['kick'])
+    @commands.command(aliases=["kick"])
     async def leave(self, ctx, guild_id: int):
         if guild := self.bot.get_guild(guild_id):
             await guild.leave()
-            await ctx.send(f"{self.bot.config['response_strings']['success']} {(await self.bot.localize(ctx.guild, 'OWNER_leave_left')).format(guild.name.replace('`', '').replace('*', ''))}")
+            await ctx.send(
+                (await self.bot.localize(ctx.guild, "OWNER_leave_left", "success")).format(
+                    guild.name.replace("`", "").replace("*", "")
+                )
+            )
         else:
-            await ctx.send(f"{self.bot.config['response_strings']['error']} {await self.bot.localize(ctx.guild, 'OWNER_leave_notfound')}")
+            await ctx.send(await self.bot.localize(ctx.guild, "OWNER_leave_notfound", "error"))
 
     @commands.command()
     async def block(self, ctx, guild_id: int):
         async with self.bot.db_connect() as db:
             await db.execute("INSERT OR IGNORE INTO blocked VALUES (?)", (guild_id,))
             await db.commit()
-        await ctx.send(f"{self.bot.config['response_strings']['success']} {await self.bot.localize(ctx.guild, 'OWNER_block_blocked')}")
+        await ctx.send(await self.bot.localize(ctx.guild, "OWNER_block_blocked", "success"))
         if guild := self.bot.get_guild(guild_id):
             await guild.leave()
-            await ctx.send(f"{self.bot.config['response_strings']['success']} {(await self.bot.localize(ctx.guild, 'OWNER_leave_left')).format(guild.name.replace('`', '').replace('*', ''))}")
+            await ctx.send(
+                (await self.bot.localize(ctx.guild, "OWNER_leave_left", "success")).format(
+                    guild.name.replace("`", "").replace("*", "")
+                )
+            )
 
     @commands.command()
     async def unblock(self, ctx, guild_id: int):
         async with self.bot.db_connect() as db:
             async with db.execute("SELECT * FROM blocked WHERE id = ?", (guild_id,)) as cur:
                 if not await cur.fetchone():
-                    return await ctx.send(f"{self.bot.config['response_strings']['error']} {await self.bot.localize(ctx.guild, 'OWNER_unblock_notfound')}")
+                    return await ctx.send(await self.bot.localize(ctx.guild, "OWNER_unblock_notfound", "error"))
             await db.execute("DELETE FROM blocked WHERE id = ?", (guild_id,))
             await db.commit()
-        await ctx.send(f"{self.bot.config['response_strings']['success']} {await self.bot.localize(ctx.guild, 'OWNER_unblock_unblocked')}")
+        await ctx.send(await self.bot.localize(ctx.guild, "OWNER_unblock_unblocked", "success"))
 
-    @commands.command(aliases=['logout', 'close'])
+    @commands.command(aliases=["logout", "close"])
     async def shutdown(self, ctx):
         try:
-            await ctx.send(content=f"{self.bot.config['response_strings']['success']} {await self.bot.localize(ctx.guild, 'OWNER_shutdown')}")
+            await ctx.send(content=await self.bot.localize(ctx.guild, "OWNER_shutdown", "success"))
         except discord.Forbidden:
             pass
         await self.bot.close()

--- a/cogs/PersonalQuotes.py
+++ b/cogs/PersonalQuotes.py
@@ -9,86 +9,169 @@ class PersonalQuotes(commands.Cog):
     async def send_quote(self, ctx, alias: str, server=False):
         await ctx.trigger_typing()
         async with self.bot.db_connect() as db:
-            if (guild := ctx.guild) and guild.me.permissions_in(ctx.channel).manage_messages and (await (await db.execute("SELECT delete_commands FROM guild WHERE id = ?", (guild.id,))).fetchone())[0]:
+            if (
+                (guild := ctx.guild)
+                and guild.me.permissions_in(ctx.channel).manage_messages
+                and (await (await db.execute("SELECT delete_commands FROM guild WHERE id = ?", (guild.id,))).fetchone())[0]
+            ):
                 await ctx.message.delete()
-            if quoted := await (await db.execute("SELECT message_id FROM personal_quote WHERE owner_id = ? AND alias = ?", (owner_id := ctx.guild.id if server else ctx.author.id, alias))).fetchone():
-                msg_dict = {'message_id': (msg_id := quoted[0])}
-                if channel_id := (await (await db.execute("SELECT channel_id FROM message WHERE id = ?", (msg_id,))).fetchone())[0]:
-                    msg_dict['channel_id'] = channel_id
-                    msg_dict['guild_id'] = (await (await db.execute("SELECT guild_id FROM channel WHERE id = ?", (channel_id,))).fetchone())[0]
+            if quoted := await (
+                await db.execute(
+                    "SELECT message_id FROM personal_quote WHERE owner_id = ? AND alias = ?",
+                    (owner_id := ctx.guild.id if server else ctx.author.id, alias),
+                )
+            ).fetchone():
+                msg_dict = {"message_id": (msg_id := quoted[0])}
+                if channel_id := (
+                    await (await db.execute("SELECT channel_id FROM message WHERE id = ?", (msg_id,))).fetchone()
+                )[0]:
+                    msg_dict["channel_id"] = channel_id
+                    msg_dict["guild_id"] = (
+                        await (await db.execute("SELECT guild_id FROM channel WHERE id = ?", (channel_id,))).fetchone()
+                    )[0]
                 else:
-                    msg_dict['dm'] = True
+                    msg_dict["dm"] = True
                 try:
                     msg = await self.bot.get_message(ctx, msg_dict)
-                except Exception as e:
-                    await db.execute('PRAGMA foreign_keys = ON')
-                    if isinstance(e, commands.ChannelNotFound):
+                except (discord.NotFound, discord.Forbidden, discord.HTTPException, commands.BadArgument) as error:
+                    await db.execute("PRAGMA foreign_keys = ON")
+                    if isinstance(error, commands.ChannelNotFound):
                         await db.execute("DELETE FROM channel WHERE id = ?", (channel_id,))
-                    elif isinstance(e, commands.MessageNotFound):
+                    elif isinstance(error, commands.MessageNotFound):
                         await db.execute("DELETE FROM message WHERE id = ?", (msg_id,))
                     else:
                         await db.execute("DELETE FROM personal_quote WHERE owner_id = ? AND alias = ?", (owner_id, alias))
                     await db.commit()
-                    if isinstance(e, discord.Forbidden):
-                        return await ctx.send(f"{self.bot.config['response_strings']['error']} {await self.bot.localize(ctx.guild, 'MAIN_quote_noperms')}")
-                    return await ctx.send(f"{self.bot.config['response_strings']['error']} {await self.bot.localize(ctx.guild, 'MAIN_quote_nomessage')}")
-                return await self.bot.quote_message(msg, ctx.channel, ctx.author, 'server' if server else 'personal')
-        await ctx.send(content=f"{self.bot.config['response_strings']['error']} {await self.bot.localize(guild, 'PERSONAL_personalquote_notfound')}")
+                    if isinstance(error, discord.Forbidden):
+                        return await ctx.send(await self.bot.localize(ctx.guild, "MAIN_quote_noperms", "error"))
+                    return await ctx.send(await self.bot.localize(ctx.guild, "MAIN_quote_nomessage", "error"))
+                return await self.bot.quote_message(msg, ctx.channel, ctx.author, "server" if server else "personal")
+        await ctx.send(content=await self.bot.localize(guild, "PERSONAL_personalquote_notfound", "error"))
 
     async def send_list(self, ctx, server=False):
-        if fetch_quotes := await self.bot.fetch("SELECT alias FROM personal_quote WHERE owner_id = ?", (ctx.guild.id if server else ctx.author.id,), False):
-            embed = discord.Embed(description=', '.join(f'`{alias}`' for alias in fetch_quotes), color=ctx.author.color.value or discord.Embed.Empty)
-            embed.set_author(name=await self.bot.localize(ctx.guild, f"PERSONAL_{'server' if server else 'personal'}list_embedauthor"), icon_url=ctx.author.avatar_url)
+        if fetch_quotes := await self.bot.fetch(
+            "SELECT alias FROM personal_quote WHERE owner_id = ?", (ctx.guild.id if server else ctx.author.id,), False
+        ):
+            embed = discord.Embed(
+                description=", ".join(f"`{alias}`" for alias in fetch_quotes),
+                color=ctx.author.color.value or discord.Embed.Empty,
+            )
+            embed.set_author(
+                name=await self.bot.localize(ctx.guild, f"PERSONAL_{'server' if server else 'personal'}list_embedauthor"),
+                icon_url=ctx.author.avatar_url,
+            )
             await ctx.send(embed=embed)
         else:
-            await ctx.send(content=f"""{self.bot.config['response_strings']['error']} {await self.bot.localize(ctx.guild, f"PERSONAL_{'server' if server else 'personal'}list_noquotes")}""")
+            await ctx.send(
+                content=await self.bot.localize(
+                    ctx.guild, f"PERSONAL_{'server' if server else 'personal'}list_noquotes", "error"
+                )
+            )
 
     async def set_quote(self, ctx, alias: str, query: str, server=False):
         if len(alias := discord.utils.escape_markdown(alias)) > 50:
-            return await ctx.send(f"{self.bot.config['response_strings']['error']} {(await self.bot.localize(ctx.guild, 'PERSONAL_personalset_invalidalias')).format(alias)}")
+            return await ctx.send(
+                (await self.bot.localize(ctx.guild, "PERSONAL_personalset_invalidalias", "error")).format(alias)
+            )
         if match := self.bot.msg_id_regex.match(query) or self.bot.msg_url_regex.match(query):
             try:
                 msg = await self.bot.get_message(ctx, match.groupdict())
             except discord.Forbidden:
-                return await ctx.send(f"{self.bot.config['response_strings']['error']} {await self.bot.localize(ctx.guild, 'MAIN_quote_noperms')}")
-            except Exception:
-                return await ctx.send(f"{self.bot.config['response_strings']['error']} {await self.bot.localize(ctx.guild, 'MAIN_quote_nomessage')}")
+                return await ctx.send(await self.bot.localize(ctx.guild, "MAIN_quote_noperms", "error"))
+            except (discord.NotFound, discord.HTTPException, commands.BadArgument):
+                return await ctx.send(await self.bot.localize(ctx.guild, "MAIN_quote_nomessage", "error"))
             async with self.bot.db_connect() as db:
-                async with db.execute("SELECT COUNT(alias) FROM personal_quote WHERE owner_id = ?", (owner_id := ctx.guild.id if server else ctx.author.id,)) as cur:
+                async with db.execute(
+                    "SELECT COUNT(alias) FROM personal_quote WHERE owner_id = ?",
+                    (owner_id := ctx.guild.id if server else ctx.author.id,),
+                ) as cur:
                     if (await cur.fetchone())[0] >= 50:
-                        return await ctx.send(f"""{self.bot.config['response_strings']['error']} {await self.bot.localize(ctx.guild, f"PERSONAL_{'server' if server else 'personal'}set_limitexceeded")}""")
+                        return await ctx.send(
+                            await self.bot.localize(
+                                ctx.guild, f"PERSONAL_{'server' if server else 'personal'}set_limitexceeded", "error"
+                            )
+                        )
                 if msg.guild:
                     await db.execute("INSERT OR IGNORE INTO channel VALUES (?, ?)", (msg.channel.id, msg.guild.id))
-                await db.execute("INSERT OR IGNORE INTO message VALUES (?, ?)", (msg.id, None if isinstance(msg.channel, discord.DMChannel) else msg.channel.id))
+                await db.execute(
+                    "INSERT OR IGNORE INTO message VALUES (?, ?)",
+                    (msg.id, None if isinstance(msg.channel, discord.DMChannel) else msg.channel.id),
+                )
                 await db.execute("INSERT OR REPLACE INTO personal_quote VALUES (?, ?, ?)", (owner_id, alias, msg.id))
                 await db.commit()
-            return await ctx.send(content=f"""{self.bot.config['response_strings']['success']} {(await self.bot.localize(ctx.guild, f"PERSONAL_{'server' if server else 'personal'}set_set")).format(alias)}""")
-        await ctx.send(f"{self.bot.config['response_strings']['error']} {await self.bot.localize(ctx.guild, 'MAIN_quote_nomessage')}")
+            return await ctx.send(
+                (
+                    await self.bot.localize(ctx.guild, f"PERSONAL_{'server' if server else 'personal'}set_set", "success")
+                ).format(alias)
+            )
+        await ctx.send(await self.bot.localize(ctx.guild, "MAIN_quote_nomessage", "error"))
 
     async def copy_quote(self, ctx, owner_id: int, alias: str, server=False):
         async with self.bot.db_connect() as db:
-            if await (await db.execute("SELECT message_id FROM personal_quote WHERE owner_id = ? AND alias = ?", (new_owner_id := ctx.guild.id if server else ctx.author.id, alias))).fetchone() or (await (await db.execute("SELECT COUNT(alias) FROM personal_quote WHERE owner_id = ?", (new_owner_id,))).fetchone())[0] < 50:
-                if copied := await (await db.execute("SELECT message_id FROM personal_quote WHERE owner_id = ? AND alias = ?", (owner_id, alias))).fetchone():
-                    await db.execute("INSERT OR REPLACE INTO personal_quote VALUES (?, ?, ?)", (new_owner_id, alias, copied[0]))
+            if (
+                await (
+                    await db.execute(
+                        "SELECT message_id FROM personal_quote WHERE owner_id = ? AND alias = ?",
+                        (new_owner_id := ctx.guild.id if server else ctx.author.id, alias),
+                    )
+                ).fetchone()
+                or (
+                    await (
+                        await db.execute("SELECT COUNT(alias) FROM personal_quote WHERE owner_id = ?", (new_owner_id,))
+                    ).fetchone()
+                )[0]
+                < 50
+            ):
+                if copied := await (
+                    await db.execute(
+                        "SELECT message_id FROM personal_quote WHERE owner_id = ? AND alias = ?", (owner_id, alias)
+                    )
+                ).fetchone():
+                    await db.execute(
+                        "INSERT OR REPLACE INTO personal_quote VALUES (?, ?, ?)", (new_owner_id, alias, copied[0])
+                    )
                     await db.commit()
-                    return await ctx.send(content=f"""{self.bot.config['response_strings']['success']} {(await self.bot.localize(ctx.guild, f"PERSONAL_{'server' if server else 'personal'}set_set")).format(alias)}""")
-                return await ctx.send(f"""{self.bot.config['response_strings']['error']} {await self.bot.localize(ctx.guild, f"PERSONAL_{'server' if server else 'personal'}set_limitexceeded")}""")
-        await ctx.send(content=f"{self.bot.config['response_strings']['error']} {await self.bot.localize(ctx.guild, 'PERSONAL_personalquote_notfound')}")
+                    return await ctx.send(
+                        content=(
+                            await self.bot.localize(
+                                ctx.guild, f"PERSONAL_{'server' if server else 'personal'}set_set", "success"
+                            )
+                        ).format(alias)
+                    )
+                return await ctx.send(
+                    await self.bot.localize(
+                        ctx.guild, f"PERSONAL_{'server' if server else 'personal'}set_limitexceeded", "error"
+                    )
+                )
+        await ctx.send(await self.bot.localize(ctx.guild, "PERSONAL_personalquote_notfound", "error"))
 
     async def remove_quote(self, ctx, alias: str, server=False):
         async with self.bot.db_connect() as db:
-            if await (await db.execute("SELECT * FROM personal_quote WHERE owner_id = ? AND alias = ?", (owner_id := ctx.guild.id if server else ctx.author.id, alias))).fetchone():
+            if await (
+                await db.execute(
+                    "SELECT * FROM personal_quote WHERE owner_id = ? AND alias = ?",
+                    (owner_id := ctx.guild.id if server else ctx.author.id, alias),
+                )
+            ).fetchone():
                 await db.execute("DELETE FROM personal_quote WHERE owner_id = ? AND alias = ?", (owner_id, alias))
                 await db.commit()
-                await ctx.send(content=f"""{self.bot.config['response_strings']['success']} {(await self.bot.localize(ctx.guild, f"PERSONAL_{'server' if server else 'personal'}remove_removed")).format(alias)}""")
+                await ctx.send(
+                    (
+                        await self.bot.localize(
+                            ctx.guild, f"PERSONAL_{'server' if server else 'personal'}remove_removed", "success"
+                        )
+                    ).format(alias)
+                )
             else:
-                await ctx.send(content=f"{self.bot.config['response_strings']['error']} {await self.bot.localize(ctx.guild, 'PERSONAL_personalquote_notfound')}")
+                await ctx.send(await self.bot.localize(ctx.guild, "PERSONAL_personalquote_notfound", "error"))
 
     async def clear_quotes(self, ctx, server=False):
         async with self.bot.db_connect() as db:
             await db.execute("DELETE FROM personal_quote WHERE owner_id = ?", (ctx.guild.id if server else ctx.author.id,))
             await db.commit()
-        await ctx.send(content=f"""{self.bot.config['response_strings']['success']} {await self.bot.localize(ctx.guild, f"PERSONAL_{'server' if server else 'personal'}clear_cleared")}""")
+        await ctx.send(
+            await self.bot.localize(ctx.guild, f"PERSONAL_{'server' if server else 'personal'}clear_cleared", "success")
+        )
 
     @commands.Cog.listener()
     async def on_guild_channel_delete(self, channel):
@@ -104,54 +187,54 @@ class PersonalQuotes(commands.Cog):
             await db.execute("DELETE FROM message WHERE id = ?", (msg.id,))
             await db.commit()
 
-    @commands.command(aliases=['personal', 'pquote', 'pq'])
+    @commands.command(aliases=["personal", "pquote", "pq"])
     async def personalquote(self, ctx, alias: str):
         await self.send_quote(ctx, alias)
 
-    @commands.command(aliases=['plist'])
+    @commands.command(aliases=["plist"])
     async def personallist(self, ctx):
         await self.send_list(ctx)
 
-    @commands.command(aliases=['pset'])
+    @commands.command(aliases=["pset"])
     async def personalset(self, ctx, alias: str, *, query: str):
         await self.set_quote(ctx, alias, query)
 
-    @commands.command(aliases=['pcopy'])
+    @commands.command(aliases=["pcopy"])
     async def personalcopy(self, ctx, owner_id: int, alias: str):
         await self.copy_quote(ctx, owner_id, alias)
 
-    @commands.command(aliases=['premove', 'pdelete', 'pdel'])
+    @commands.command(aliases=["premove", "pdelete", "pdel"])
     async def personalremove(self, ctx, alias: str):
         await self.remove_quote(ctx, alias)
 
-    @commands.command(aliases=['pclear'])
+    @commands.command(aliases=["pclear"])
     async def personalclear(self, ctx):
         await self.clear_quotes(ctx)
 
-    @commands.command(aliases=['server', 'squote', 'sq'])
+    @commands.command(aliases=["server", "squote", "sq"])
     async def serverquote(self, ctx, alias: str):
         await self.send_quote(ctx, alias, True)
 
-    @commands.command(aliases=['slist'])
+    @commands.command(aliases=["slist"])
     async def serverlist(self, ctx):
         await self.send_list(ctx, True)
 
-    @commands.command(aliases=['sset'])
+    @commands.command(aliases=["sset"])
     @commands.has_permissions(manage_messages=True)
     async def serverset(self, ctx, alias: str, *, query: str):
         await self.set_quote(ctx, alias, query, True)
 
-    @commands.command(aliases=['scopy'])
+    @commands.command(aliases=["scopy"])
     @commands.has_permissions(manage_messages=True)
     async def servercopy(self, ctx, owner_id: int, alias: str):
         await self.copy_quote(ctx, owner_id, alias, True)
 
-    @commands.command(aliases=['sremove', 'sdelete', 'sdel'])
+    @commands.command(aliases=["sremove", "sdelete", "sdel"])
     @commands.has_permissions(manage_messages=True)
     async def serverremove(self, ctx, alias: str):
         await self.remove_quote(ctx, alias, True)
 
-    @commands.command(aliases=['sclear'])
+    @commands.command(aliases=["sclear"])
     @commands.has_permissions(manage_messages=True)
     async def serverclear(self, ctx):
         await self.clear_quotes(ctx, True)

--- a/cogs/Snipe.py
+++ b/cogs/Snipe.py
@@ -40,23 +40,28 @@ class Snipe(commands.Cog):
         await ctx.trigger_typing()
         if not channel:
             channel = ctx.channel
-        if not ctx.author.permissions_in(channel).read_messages or not ctx.author.permissions_in(channel).read_message_history:
+        if (
+            not ctx.author.permissions_in(channel).read_messages
+            or not ctx.author.permissions_in(channel).read_message_history
+        ):
             return
 
         if guild := ctx.guild:
-            if (perms := guild.me.permissions_in(ctx.channel)).manage_messages and (await self.bot.fetch("SELECT delete_commands FROM guild WHERE id = ?", (guild.id,))):
+            if (perms := guild.me.permissions_in(ctx.channel)).manage_messages and (
+                await self.bot.fetch("SELECT delete_commands FROM guild WHERE id = ?", (guild.id,))
+            ):
                 await ctx.message.delete()
             if not perms.send_messages:
                 return
             elif not perms.embed_links:
-                return await ctx.send(f"{self.bot.config['response_strings']['error']} {await self.bot.localize(guild, 'META_perms_noembed')}")
+                return await ctx.send(await self.bot.localize(guild, "META_perms_noembed", "error"))
 
         try:
             msg = (self.edits if edit else self.deletes)[channel.guild.id][channel.id]
         except KeyError:
-            await ctx.send(f"{self.bot.config['response_strings']['error']} {await self.bot.localize(guild, 'MAIN_quote_nomessage')}")
+            await ctx.send(await self.bot.localize(guild, "MAIN_quote_nomessage", "error"))
         else:
-            await self.bot.quote_message(msg, ctx.channel, ctx.author, 'snipe')
+            await self.bot.quote_message(msg, ctx.channel, ctx.author, "snipe")
 
     @commands.command()
     async def snipe(self, ctx, channel: discord.TextChannel = None):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+[tool.black]
+line-length = 125
+
+[tool.isort]
+profile = "black"
+line_length = 125
+
+[tool.pylint.messages_control]
+disable = "C0330, C0326, C0111, W0212"
+
+[tool.pylint.format]
+max-line-length = "125"

--- a/quote.py
+++ b/quote.py
@@ -1,10 +1,10 @@
 import json
 import os
+import re
 from functools import partial
+from sqlite3 import Error, PARSE_COLNAMES, PARSE_DECLTYPES
 from sys import stderr
 from traceback import print_tb
-import re
-from sqlite3 import PARSE_COLNAMES, PARSE_DECLTYPES
 
 import discord
 from aiohttp import ClientSession
@@ -15,10 +15,12 @@ from discord.ext import commands
 async def get_prefix(bot, msg):
     if msg.guild:
         try:
-            return commands.when_mentioned_or(await bot.fetch("SELECT prefix FROM guild WHERE id = ?", (msg.guild.id,)))(bot, msg)
-        except Exception:
+            return commands.when_mentioned_or(await bot.fetch("SELECT prefix FROM guild WHERE id = ?", (msg.guild.id,)))(
+                bot, msg
+            )
+        except (AttributeError, Error):
             pass
-    return commands.when_mentioned_or(bot.config['default_prefix'])(bot, msg)
+    return commands.when_mentioned_or(bot.config["default_prefix"])(bot, msg)
 
 
 class QuoteBotHelpCommand(commands.HelpCommand):
@@ -33,15 +35,20 @@ class QuoteBotHelpCommand(commands.HelpCommand):
         bot = ctx.bot
         prefix = (await get_prefix(bot, ctx.message))[-1]
         guild = ctx.guild
-        embed = discord.Embed(color=(guild and guild.me.color.value) or bot.config['default_embed_color'])
-        embed.add_field(name=await bot.localize(guild, 'HELPEMBED_links'),
-                        value=f"[{await bot.localize(guild, 'HELPEMBED_supportserver')}](https://discord.gg/vkWyTGa)\n"
-                              f"[{await bot.localize(guild, 'HELPEMBED_addme')}](https://discordapp.com/oauth2/authorize?client_id={bot.user.id}&permissions=537257984&scope=bot)\n"
-                              f"[{await bot.localize(guild, 'HELPEMBED_website')}](https://quote-bot.tk/)\n"
-                              "[GitHub](https://github.com/Quote-Bot/QuoteBot)")
-        embed.add_field(name=await bot.localize(guild, 'HELPEMBED_commands'),
-                        value=', '.join(f'`{prefix}{command}`' for command in sorted(c.name for c in bot.commands)))
-        embed.set_footer(text=(await bot.localize(guild, 'HELPEMBED_footer')).format(prefix))
+        embed = discord.Embed(color=(guild and guild.me.color.value) or bot.config["default_embed_color"])
+        embed.add_field(
+            name=await bot.localize(guild, "HELPEMBED_links"),
+            value=f"[{await bot.localize(guild, 'HELPEMBED_supportserver')}](https://discord.gg/vkWyTGa)\n"
+            f"[{await bot.localize(guild, 'HELPEMBED_addme')}](https://discordapp.com/oauth2/authorize?client_id="
+            f"{bot.user.id}&permissions=537257984&scope=bot)\n"
+            f"[{await bot.localize(guild, 'HELPEMBED_website')}](https://quote-bot.tk/)\n"
+            "[GitHub](https://github.com/Quote-Bot/QuoteBot)",
+        )
+        embed.add_field(
+            name=await bot.localize(guild, "HELPEMBED_commands"),
+            value=", ".join(f"`{prefix}{command}`" for command in sorted(c.name for c in bot.commands)),
+        )
+        embed.set_footer(text=(await bot.localize(guild, "HELPEMBED_footer")).format(prefix))
         await ctx.send(embed=embed)
 
     async def send_cog_help(self, cog):
@@ -50,44 +57,52 @@ class QuoteBotHelpCommand(commands.HelpCommand):
     async def send_command_help(self, command):
         ctx = self.context
         bot = ctx.bot
-        embed = discord.Embed(color=ctx.guild.me.color.value or bot.config['default_embed_color'],
-                              title=self.get_command_signature(command),
-                              description=await bot.localize(ctx.guild, f'HELP_{command.name}'))
+        embed = discord.Embed(
+            color=(ctx.guild and ctx.guild.me.color.value) or bot.config["default_embed_color"],
+            title=self.get_command_signature(command),
+            description=await bot.localize(ctx.guild, f"HELP_{command.name}"),
+        )
         await ctx.send(embed=embed)
 
     async def send_error_message(self, error):
         ctx = self.context
         bot = ctx.bot
-        return await ctx.send(f"{bot.config['response_strings']['error']} {(await bot.localize(ctx.guild, 'HELP_notfound')).format(repr(error))}")
+        return await ctx.send((await bot.localize(ctx.guild, "HELP_notfound", "error")).format(repr(error)))
 
 
 class QuoteBot(commands.AutoShardedBot):
     def __init__(self, config):
-        super().__init__(help_command=QuoteBotHelpCommand(),
-                         command_prefix=get_prefix,
-                         case_insensitive=True,
-                         owner_ids=set(config['owner_ids']),
-                         status=discord.Status.idle,
-                         activity=discord.Game('starting up...'),
-                         max_messages=config['max_message_cache'],
-                         intents=discord.Intents(guild_messages=True,
-                                                 guild_reactions=True,
-                                                 guilds=True,
-                                                 dm_messages=config['intents']['dm_messages'],
-                                                 members=config['intents']['members']))
+        super().__init__(
+            help_command=QuoteBotHelpCommand(),
+            command_prefix=get_prefix,
+            case_insensitive=True,
+            owner_ids=set(config["owner_ids"]),
+            status=discord.Status.idle,
+            activity=discord.Game("starting up..."),
+            max_messages=config["max_message_cache"],
+            intents=discord.Intents(
+                guild_messages=True,
+                guild_reactions=True,
+                guilds=True,
+                dm_messages=config["intents"]["dm_messages"],
+                members=config["intents"]["members"],
+            ),
+        )
 
         self.config = config
-        self.db_connect = partial(connect, 'configs/QuoteBot.db', detect_types=PARSE_DECLTYPES | PARSE_COLNAMES)
+        self.db_connect = partial(connect, "configs/QuoteBot.db", detect_types=PARSE_DECLTYPES | PARSE_COLNAMES)
 
-        self.msg_id_regex = re.compile(r'(?:(?P<channel_id>[0-9]{15,21})(?:-|/|\s))?(?P<message_id>[0-9]{15,21})$')
-        self.msg_url_regex = re.compile(r'https?://(?:(canary|ptb|www)\.)?discord(?:app)?\.com/channels/'
-                                        r'(?:(?P<guild_id>[0-9]{15,21})|(?P<dm>@me))/(?P<channel_id>[0-9]{15,21})/'
-                                        r'(?P<message_id>[0-9]{15,21})/?(?:$|\s)')
+        self.msg_id_regex = re.compile(r"(?:(?P<channel_id>[0-9]{15,21})(?:-|/|\s))?(?P<message_id>[0-9]{15,21})$")
+        self.msg_url_regex = re.compile(
+            r"https?://(?:(canary|ptb|www)\.)?discord(?:app)?\.com/channels/"
+            r"(?:(?P<guild_id>[0-9]{15,21})|(?P<dm>@me))/(?P<channel_id>[0-9]{15,21})/"
+            r"(?P<message_id>[0-9]{15,21})/?(?:$|\s)"
+        )
 
         self.responses = dict()
 
-        for filename in os.listdir(path='localization'):
-            with open(os.path.join('localization', filename), encoding='utf-8') as json_data:
+        for filename in os.listdir(path="localization"):
+            with open(os.path.join("localization", filename), encoding="utf-8") as json_data:
                 self.responses[filename[:-5]] = json.load(json_data)
 
         self.loop.create_task(self.startup())
@@ -96,7 +111,8 @@ class QuoteBot(commands.AutoShardedBot):
         async with self.db_connect() as db:
             await db.execute("PRAGMA auto_vacuum = 1")
             await db.execute("PRAGMA foreign_keys = ON")
-            await db.execute(f"""
+            await db.execute(
+                f"""
                 CREATE TABLE
                 IF NOT EXISTS guild (
                     id INTEGER PRIMARY KEY,
@@ -107,22 +123,28 @@ class QuoteBot(commands.AutoShardedBot):
                     delete_commands INTEGER DEFAULT 0 NOT NULL,
                     pin_channel INTEGER
                 )
-            """)
-            await db.execute("""
+            """
+            )
+            await db.execute(
+                """
                 CREATE TABLE
                 IF NOT EXISTS channel (
                     id INTEGER NOT NULL PRIMARY KEY,
                     guild_id INTEGER NOT NULL REFERENCES guild ON DELETE CASCADE
                 )
-            """)
-            await db.execute("""
+            """
+            )
+            await db.execute(
+                """
                 CREATE TABLE
                 IF NOT EXISTS message (
                     id INTEGER NOT NULL PRIMARY KEY,
                     channel_id INTEGER REFERENCES channel ON DELETE CASCADE
                 )
-            """)
-            await db.execute("""
+            """
+            )
+            await db.execute(
+                """
                 CREATE TABLE
                 IF NOT EXISTS personal_quote (
                     owner_id INTEGER NOT NULL REFERENCES guild ON DELETE CASCADE,
@@ -130,33 +152,40 @@ class QuoteBot(commands.AutoShardedBot):
                     message_id INTEGER NOT NULL REFERENCES message ON DELETE CASCADE,
                     PRIMARY KEY (owner_id, alias)
                 )
-            """)
-            await db.execute("""
+            """
+            )
+            await db.execute(
+                """
                 CREATE TABLE
                 IF NOT EXISTS highlight (
                     user_id INTEGER NOT NULL,
                     query TEXT NOT NULL,
                     PRIMARY KEY (user_id, query)
                 )
-            """)
-            await db.execute("""
+            """
+            )
+            await db.execute(
+                """
                 CREATE TABLE
                 IF NOT EXISTS blocked (
                     id INTEGER NOT NULL PRIMARY KEY
                 )
-            """)
+            """
+            )
             await db.commit()
 
     async def _update_presence(self):
-        await self.change_presence(activity=discord.Activity(
+        await self.change_presence(
+            activity=discord.Activity(
                 name=f"messages in {'1 server' if (guild_count := len(self.guilds)) == 1 else f'{guild_count} servers'}",
-                type=discord.ActivityType.watching))
+                type=discord.ActivityType.watching,
+            )
+        )
 
     async def startup(self):
         self.session = ClientSession(loop=self.loop)
-        if botlog_webhook_url := self.config['botlog_webhook_url']:
-            self.webhook = discord.Webhook.from_url(botlog_webhook_url,
-                                                    adapter=discord.AsyncWebhookAdapter(self.session))
+        if botlog_webhook_url := self.config["botlog_webhook_url"]:
+            self.webhook = discord.Webhook.from_url(botlog_webhook_url, adapter=discord.AsyncWebhookAdapter(self.session))
         await self._prepare_db()
         await self.wait_until_ready()
         self.owner_ids.add((await self.application_info()).owner.id)
@@ -164,15 +193,17 @@ class QuoteBot(commands.AutoShardedBot):
         if guilds := self.guilds:
             async with self.db_connect() as db:
                 db.row_factory = lambda cur, row: row[0]
-                async with db.execute(f"SELECT id FROM guild WHERE id NOT IN ({', '.join(str(guild.id) for guild in guilds)})") as cur:
-                    removed_guild_ids = ', '.join(str(guild_id) for guild_id in await cur.fetchall())
+                async with db.execute(
+                    f"SELECT id FROM guild WHERE id NOT IN ({', '.join(str(guild.id) for guild in guilds)})"
+                ) as cur:
+                    removed_guild_ids = ", ".join(str(guild_id) for guild_id in await cur.fetchall())
                 if removed_guild_ids:
                     await db.execute(f"DELETE FROM guild WHERE id IN ({removed_guild_ids})")
                     await db.execute(f"DELETE FROM personal_quote WHERE owner_id IN ({removed_guild_ids})")
                 for guild in guilds:
                     try:
                         await self.insert_new_guild(db, guild)
-                    except Exception:
+                    except Error:
                         continue
                 await db.commit()
 
@@ -185,81 +216,91 @@ class QuoteBot(commands.AutoShardedBot):
             async with db.execute(sql, params) as cur:
                 return await cur.fetchone() if one else await cur.fetchall()
 
-    async def localize(self, guild, query):
+    async def localize(self, guild, query, response_type=None):
         try:
-            return self.responses[(await self.fetch("SELECT language FROM guild WHERE id = ?", (guild.id,)))][query]
-        except Exception:
-            return self.responses[self.config['default_lang']][query]
+            response = self.responses[(await self.fetch("SELECT language FROM guild WHERE id = ?", (guild.id,)))][query]
+        except (AttributeError, KeyError):
+            response = self.responses[self.config["default_lang"]][query]
+        if response_type is None:
+            return response
+        return f"{self.config['response_strings'][response_type]} {response}"
 
     async def get_message(self, ctx, msg_dict):
-        msg_id = int(msg_dict['message_id'])
-        if msg_dict.get('dm'):
-            return discord.utils.get(self.cached_messages,
-                                     channel=(channel := await ctx.author.create_dm()),
-                                     id=msg_id) or await channel.fetch_message(msg_id)
-        if channel_id := msg_dict.get('channel_id'):
+        msg_id = int(msg_dict["message_id"])
+        if msg_dict.get("dm"):
+            return ctx.author._state._get_message(msg_id) or await ctx.author.fetch_message(msg_id)
+        if channel_id := msg_dict.get("channel_id"):
             channel_id = int(channel_id)
-            if msg := discord.utils.get(self.cached_messages, channel__id=channel_id, id=msg_id):
-                return msg
-
-            if guild_id := msg_dict.get('guild_id'):
-                guild_id = int(guild_id)
-                if msg := discord.utils.get(self.cached_messages, guild__id=guild_id, id=msg_id):
-                    return msg
-                if guild := self.get_guild(guild_id):
-                    if channel := guild.get_channel(channel_id):
-                        if msg := await channel.fetch_message(msg_id):
-                            return msg
-                        raise commands.MessageNotFound(msg_id)
+            if guild_id := msg_dict.get("guild_id"):
+                if not (guild := self.get_guild(int(guild_id))) or not (channel := guild.get_channel(channel_id)):
+                    raise commands.ChannelNotFound(channel_id)
+            elif not (channel := self.get_channel(channel_id)):
                 raise commands.ChannelNotFound(channel_id)
-
-            if channel := self.bot.get_channel(channel_id):
-                if msg := await channel.fetch_message(msg_id):
-                    return msg
-                raise commands.MessageNotFound(msg_id)
-            raise commands.ChannelNotFound(channel_id)
-
+            return channel._state._get_message(msg_id) or await channel.fetch_message(msg_id)
+        if msg := ctx._state._get_message(msg_id) or self._connection._get_message(msg_id):
+            return msg
         try:
-            return discord.utils.get(self.cached_messages,
-                                     channel=ctx.channel,
-                                     id=msg_id) or await ctx.channel.fetch_message(msg_id)
+            return await ctx.channel.fetch_message(msg_id)
         except (discord.NotFound, discord.Forbidden):
-            if guild := ctx.guild:
-                for channel in guild.text_channels:
-                    if channel == ctx.channel:
-                        continue
-                    try:
-                        return await channel.fetch_message(msg_id)
-                    except (discord.NotFound, discord.Forbidden):
-                        continue
             try:
                 return await ctx.author.fetch_message(msg_id)
             except (discord.NotFound, discord.Forbidden):
-                if msg := self._connection._get_message(msg_id) or discord.utils.get(self.cached_messages, id=msg_id):
-                    return msg
+                if guild := ctx.guild:
+                    for channel in guild.text_channels:
+                        if channel == ctx.channel:
+                            continue
+                        try:
+                            return await channel.fetch_message(msg_id)
+                        except (discord.NotFound, discord.Forbidden):
+                            continue
             raise
 
     async def insert_new_guild(self, db, guild):
-        await db.execute("INSERT OR IGNORE INTO guild (id, prefix, language) VALUES (?, ?, ?)",
-                         (guild.id, self.config['default_prefix'], self.config['default_lang']))
+        await db.execute(
+            "INSERT OR IGNORE INTO guild (id, prefix, language) VALUES (?, ?, ?)",
+            (guild.id, self.config["default_prefix"], self.config["default_lang"]),
+        )
 
-    async def quote_message(self, msg, destination, quoted_by, type='quote'):
-        guild = getattr(destination, 'guild', None)
+    async def quote_message(self, msg, destination, quoted_by, quote_type="quote"):
+        guild = getattr(destination, "guild", None)
         from_dm = isinstance(msg.channel, discord.DMChannel)
         if not msg.content and msg.embeds:
-            return await destination.send((await self.localize(guild, f'MAIN_{type}_rawembed')).format(quoted_by, msg.author, (self.user if from_dm else msg.channel).mention), embed=msg.embeds[0])
-        embed = discord.Embed(description=msg.content if msg.guild == guild else msg.clean_content, color=msg.author.color.value or discord.Embed.Empty, timestamp=msg.created_at)
+            return await destination.send(
+                (await self.localize(guild, f"MAIN_{quote_type}_rawembed")).format(
+                    quoted_by, msg.author, (self.user if from_dm else msg.channel).mention
+                ),
+                embed=msg.embeds[0],
+            )
+        embed = discord.Embed(
+            description=msg.content if msg.guild == guild else msg.clean_content,
+            color=msg.author.color.value or discord.Embed.Empty,
+            timestamp=msg.created_at,
+        )
         embed.set_author(name=str(msg.author), url=msg.jump_url, icon_url=msg.author.avatar_url)
         if msg.attachments:
-            if not from_dm and msg.channel.is_nsfw() and (isinstance(destination, (discord.DMChannel, discord.User)) or not destination.is_nsfw()):
-                embed.add_field(name=f"{await self.localize(guild, 'MAIN_quote_attachments')}",
-                                value=f":underage: {await self.localize(guild, 'MAIN_quote_nonsfw')}")
-            elif len(msg.attachments) == 1 and (url := msg.attachments[0].url).lower().endswith(('.jpg', '.jpeg', '.jfif', '.png', '.gif', '.gifv', '.webp', '.bmp', '.svg', '.tiff')):
+            if (
+                not from_dm
+                and msg.channel.is_nsfw()
+                and (isinstance(destination, (discord.DMChannel, discord.User)) or not destination.is_nsfw())
+            ):
+                embed.add_field(
+                    name=f"{await self.localize(guild, 'MAIN_quote_attachments')}",
+                    value=f":underage: {await self.localize(guild, 'MAIN_quote_nonsfw')}",
+                )
+            elif len(msg.attachments) == 1 and (url := msg.attachments[0].url).lower().endswith(
+                (".jpg", ".jpeg", ".jfif", ".png", ".gif", ".gifv", ".webp", ".bmp", ".svg", ".tiff")
+            ):
                 embed.set_image(url=url)
             else:
-                embed.add_field(name=f"{await self.localize(guild, 'MAIN_quote_attachments')}",
-                                value='\n'.join(f'[{attachment.filename}]({attachment.url})' for attachment in msg.attachments))
-        embed.set_footer(text=(await self.localize(guild, f'MAIN_{type}_embedfooter')).format(quoted_by, self.user if from_dm else f'#{msg.channel.name}'))
+                embed.add_field(
+                    name=f"{await self.localize(guild, 'MAIN_quote_attachments')}",
+                    value="\n".join(f"[{attachment.filename}]({attachment.url})" for attachment in msg.attachments),
+                )
+        embed.set_footer(
+            text=(await self.localize(guild, f"MAIN_{quote_type}_embedfooter")).format(
+                quoted_by, self.user if from_dm else f"#{msg.channel.name}"
+            )
+        )
         await destination.send(embed=embed)
 
     async def on_ready(self):
@@ -273,7 +314,7 @@ class QuoteBot(commands.AutoShardedBot):
             async with self.db_connect() as db:
                 await self.insert_new_guild(db, guild)
                 await db.commit()
-        except Exception:
+        except Error:
             pass
 
     async def on_guild_remove(self, guild):
@@ -288,23 +329,29 @@ class QuoteBot(commands.AutoShardedBot):
             await self.process_commands(msg)
 
     async def on_command_error(self, ctx, error):
-        if isinstance(error, commands.CommandNotFound) or hasattr(ctx.command, 'on_error'):
+        if isinstance(error, commands.CommandNotFound) or hasattr(ctx.command, "on_error"):
             return
-        if isinstance(error := getattr(error, 'original', error), commands.NoPrivateMessage):
+        if isinstance(error := getattr(error, "original", error), commands.NoPrivateMessage):
             try:
-                await ctx.author.send(f"{self.config['response_strings']['error']} {await self.localize(ctx.guild, 'META_command_noprivatemsg')}")
+                await ctx.author.send(await self.localize(ctx.guild, "META_command_noprivatemsg", "error"))
             except discord.HTTPException:
                 pass
         elif isinstance(error, commands.CommandOnCooldown):
-            await ctx.send(f"{self.config['response_strings']['error']} {(await self.localize(ctx.guild, 'META_command_oncooldown')).format(round(error.retry_after, 1))}")
+            await ctx.send(
+                (await self.localize(ctx.guild, "META_command_oncooldown", "error")).format(round(error.retry_after, 1))
+            )
         elif isinstance(error, commands.CheckFailure):
-            await ctx.send(f"{self.config['response_strings']['error']} {await self.localize(ctx.guild, 'META_command_noperms')}")
+            await ctx.send(await self.localize(ctx.guild, "META_command_noperms", "error"))
         elif isinstance(error, commands.UserInputError):
-            await ctx.send(f"{self.config['response_strings']['error']} {(await self.localize(ctx.guild, 'META_command_inputerror')).format(f'{(await self.get_prefix(ctx.message))[-1]}help {ctx.command.qualified_name}')}")
+            await ctx.send(
+                (await self.localize(ctx.guild, "META_command_inputerror", "error")).format(
+                    f"{(await self.get_prefix(ctx.message))[-1]}help {ctx.command.qualified_name}"
+                )
+            )
         else:
             if isinstance(error, discord.HTTPException):
-                print(f'In {ctx.command.qualified_name}:', file=stderr)
-            print(f'{error.__class__.__name__}: {error}', file=stderr)
+                print(f"In {ctx.command.qualified_name}:", file=stderr)
+            print(f"{error.__class__.__name__}: {error}", file=stderr)
             print_tb(error.__traceback__)
 
     async def close(self):
@@ -313,18 +360,18 @@ class QuoteBot(commands.AutoShardedBot):
         await super().close()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     print("Starting QuoteBot...")
-    with open(os.path.join('configs', 'credentials.json')) as json_data:
+    with open(os.path.join("configs", "credentials.json")) as json_data:
         config = json.load(json_data)
         bot = QuoteBot(config)
 
-    extensions = ['cogs.Main', 'cogs.OwnerOnly', 'cogs.PersonalQuotes', 'cogs.Snipe', 'cogs.Highlights']
+    extensions = ["cogs.Main", "cogs.OwnerOnly", "cogs.PersonalQuotes", "cogs.Snipe", "cogs.Highlights"]
 
     for extension in extensions:
         bot.load_extension(extension)
 
-    if bot.config['botlog_webhook_url']:
-        bot.load_extension('cogs.Botlog')
+    if bot.config["botlog_webhook_url"]:
+        bot.load_extension("cogs.Botlog")
 
-    bot.run(config['token'])
+    bot.run(config["token"])


### PR DESCRIPTION
This improves the code formatting by using [black](https://black.readthedocs.io/en/stable/) as auto-formatter, which I suggest we use as a standard for this project from now on. I added black-compatible configurations for [isort](https://pycqa.github.io/isort/) and [pylint](https://pylint.org/) (default linter in VS Code/Codium) in `pyconfig.toml`. Most of the popular Python IDEs can be configured to automatically apply black and isort when saving files, which I would recommend. I also managed to improve quoting efficiency a little more by using a different method to retrieve messages from cache and by removing more redundant checks.