### PR TITLE
Add hybrid commands, quote from context menu, misc. fixes

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -15,7 +15,7 @@ isort = "*"
 pre-commit = "*"
 
 [requires]
-python_version = "3.9"
+python_version = "3.10"
 
 [scripts]
 bot = "python bot.py"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b174df115d80b3028deeb5f60ad2e8e34a6d3c077a7923d7ecab98ac1a359eae"
+            "sha256": "40a36b112e4fc1d81c263f3d238b3d152748e35ffbba3715f0b47fe0933adb58"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.9"
+            "python_version": "3.10"
         },
         "sources": [
             {
@@ -128,11 +128,11 @@
         },
         "charset-normalizer": {
             "hashes": [
-                "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597",
-                "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"
+                "sha256:5189b6f22b01957427f35b6a08d9a0bc45b46d3788ef5a92e978433c7a35f8a5",
+                "sha256:575e708016ff3a5e3681541cb9d79312c416835686d054a23accb873b254f413"
             ],
-            "markers": "python_full_version >= '3.5.0'",
-            "version": "==2.0.12"
+            "markers": "python_version >= '3.6'",
+            "version": "==2.1.0"
         },
         "discord-py": {
             "git": "https://github.com/Rapptz/discord.py.git",
@@ -212,7 +212,7 @@
                 "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff",
                 "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"
             ],
-            "markers": "python_full_version >= '3.5.0'",
+            "markers": "python_version >= '3.5'",
             "version": "==3.3"
         },
         "multidict": {
@@ -437,11 +437,11 @@
         },
         "colorama": {
             "hashes": [
-                "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b",
-                "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"
+                "sha256:854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da",
+                "sha256:e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4"
             ],
             "markers": "platform_system == 'Windows'",
-            "version": "==0.4.4"
+            "version": "==0.4.5"
         },
         "distlib": {
             "hashes": [

--- a/bot.py
+++ b/bot.py
@@ -258,9 +258,7 @@ class QuoteBot(commands.AutoShardedBot):
         source = self.user if msg.channel.type == discord.ChannelType.private else f"#{msg.channel.name}"
         if destination_guild is not None and msg.guild is not None and msg.guild != destination_guild:
             source = f"{source} ({msg.guild.name})"
-        embed.set_footer(
-            text=f"{self._QUOTE_TYPE_TEXT[quote_type].footer} by @\u200b{quoted_by} from @\u200b{msg.author}{f' in {source}' if source != msg.author else ''}"
-        )
+        embed.set_footer(text=f"{self._QUOTE_TYPE_TEXT[quote_type].footer} by @\u200b{quoted_by} from {source}")
 
     async def on_ready(self) -> None:
         await self._update_presence()

--- a/cogs/botlog.py
+++ b/cogs/botlog.py
@@ -38,14 +38,15 @@ class BotLog(commands.Cog):
 
     async def _send_guild_update(self, guild: discord.Guild, join: bool = True) -> None:
         bot = self.bot
+        if bot.user is None:
+            return
         async with bot.db_connect() as con:
             if await con.is_blocked(guild.id):
                 return
-
         try:
             await self.webhook.send(
                 username=bot.user.name,
-                avatar_url=getattr(bot.user.avatar, "url", DEFAULT_AVATAR_URL),
+                avatar_url=getattr(bot.user.display_avatar, "url", DEFAULT_AVATAR_URL),
                 content=f":{'in' if join else 'out'}box_tray: **Guild {'added' if join else 'removed'}: "
                 f"{discord.utils.escape_markdown(guild.name)}** (ID: {guild.id})\n"
                 f"Total guild members: {guild.member_count}\nTotal guilds: {len(bot.guilds)}",

--- a/cogs/highlights.py
+++ b/cogs/highlights.py
@@ -141,7 +141,7 @@ class Highlights(commands.Cog):
                     value=pattern,
                 )
                 for pattern in await con.fetch_user_highlights_starting_with(interaction.user.id, current)
-            ]
+            ][:25]
 
     @commands.hybrid_command(aliases=["hlclear"])
     async def highlightclear(self, ctx: commands.Context) -> None:

--- a/cogs/savedquotes.py
+++ b/cogs/savedquotes.py
@@ -112,7 +112,7 @@ class SavedQuotes(commands.Cog):
             await ctx.send(f":x: **Alias can't be longer than {_MAX_ALIAS_LENGTH} characters.**")
             return
         try:
-            msg = await ctx.get_message(query)
+            msg = await anext(ctx.get_messages(query))
         except commands.BadArgument:
             await ctx.send(":x: **Couldn't find the message.**")
         except discord.Forbidden:

--- a/cogs/savedquotes.py
+++ b/cogs/savedquotes.py
@@ -229,7 +229,7 @@ class SavedQuotes(commands.Cog):
                 )
                 for alias in await con.fetch_owner_aliases(interaction.user.id)
                 if current.lower() in alias.lower()
-            ]
+            ][:25]
 
     @commands.hybrid_command(aliases=["server", "squote", "sq"])
     @commands.guild_only()
@@ -277,7 +277,7 @@ class SavedQuotes(commands.Cog):
                     value=alias,
                 )
                 for alias in await con.fetch_owner_aliases(interaction.guild.id)
-            ]
+            ][:25]
 
     @commands.hybrid_command(aliases=["sclear"])
     @commands.has_permissions(manage_messages=True)

--- a/cogs/settings.py
+++ b/cogs/settings.py
@@ -23,7 +23,7 @@ class Settings(commands.Cog):
     def __init__(self, bot: QuoteBot) -> None:
         self.bot = bot
 
-    @commands.command(aliases=["togglereactions", "togglereact", "reactions"])
+    @commands.hybrid_command(aliases=["togglereactions", "togglereact", "reactions"])
     @commands.has_permissions(manage_guild=True)
     @commands.guild_only()
     async def togglereaction(self, ctx: commands.Context) -> None:
@@ -38,7 +38,7 @@ class Settings(commands.Cog):
             await con.commit()
         await ctx.send(f":white_check_mark: **Quoting messages by adding reactions {'enabled' if new else 'disabled'}.**")
 
-    @commands.command(aliases=["links"])
+    @commands.hybrid_command(aliases=["links"])
     @commands.has_permissions(manage_guild=True)
     @commands.guild_only()
     async def togglelinks(self, ctx: commands.Context) -> None:
@@ -53,7 +53,7 @@ class Settings(commands.Cog):
             await con.commit()
         await ctx.send(f":white_check_mark: **Quoting linked messages {'enabled' if new else 'disabled'}.**")
 
-    @commands.command(aliases=["delcommands", "delete"])
+    @commands.hybrid_command(aliases=["delcommands", "delete"])
     @commands.has_permissions(manage_guild=True)
     @commands.bot_has_guild_permissions(manage_messages=True)
     @commands.guild_only()
@@ -69,7 +69,7 @@ class Settings(commands.Cog):
             await con.commit()
         await ctx.send(f":white_check_mark: **Deleting quote command messages {'enabled' if new else 'disabled'}.**")
 
-    @commands.command(aliases=["snipepermission", "snipeperms"])
+    @commands.hybrid_command(aliases=["snipepermission", "snipeperms"])
     @commands.has_permissions(manage_guild=True)
     @commands.guild_only()
     async def togglesnipepermission(self, ctx: commands.Context) -> None:
@@ -86,7 +86,7 @@ class Settings(commands.Cog):
             f":white_check_mark: **Snipe commands {'now' if new else 'no longer'} require the 'Manage Messages' permission.**"
         )
 
-    @commands.command(aliases=["prefix"])
+    @commands.hybrid_command(aliases=["prefix"])
     @commands.has_permissions(manage_guild=True)
     @commands.guild_only()
     async def setprefix(self, ctx: commands.Context, prefix: str) -> None:

--- a/cogs/snipe.py
+++ b/cogs/snipe.py
@@ -100,7 +100,7 @@ class Snipe(commands.Cog):
         except KeyError:
             await ctx.send(":x: **Couldn't find the message.**")
         else:
-            await self.bot.quote_message(msg, ctx.channel, str(ctx.author), "snipe")
+            await self.bot.quote_message(msg, ctx.channel, ctx.send, str(ctx.author), "snipe")
 
     async def _snipe_if_permitted(
         self, ctx: commands.Context, channel_or_thread: TextChannelOrThread, edit: bool = False
@@ -125,7 +125,7 @@ class Snipe(commands.Cog):
         async with self.bot.db_connect() as con:
             return not await con.fetch_snipe_requires_manage_messages(channel_or_thread.guild.id)
 
-    @commands.command()
+    @commands.hybrid_command()
     @delete_message_if_needed
     async def snipe(
         self, ctx: commands.Context, channel_or_thread: Optional[GlobalTextChannelOrThreadConverter] = None
@@ -133,7 +133,7 @@ class Snipe(commands.Cog):
         """Snipe the last cached deleted message from a specified channel or the current channel."""
         await self._snipe_if_permitted(ctx, channel_or_thread)  # type: ignore
 
-    @commands.command()
+    @commands.hybrid_command()
     @delete_message_if_needed
     async def snipeedit(
         self, ctx: commands.Context, channel_or_thread: Optional[GlobalTextChannelOrThreadConverter] = None

--- a/core/help.py
+++ b/core/help.py
@@ -14,7 +14,7 @@ GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
-from typing import Mapping, Optional
+from typing import List, Mapping, Optional
 
 import discord
 from discord.ext import commands
@@ -39,7 +39,7 @@ class QuoteBotHelpCommand(commands.HelpCommand):
     def subcommand_not_found(self, command: commands.Command, string: str) -> str:
         return string
 
-    async def send_bot_help(self, mapping: Mapping[Optional[commands.Cog], list[commands.Command]]) -> None:
+    async def send_bot_help(self, mapping: Mapping[Optional[commands.Cog], List[commands.Command]]) -> None:
         ctx = self.context
         bot = ctx.bot
         prefix = (await bot.get_prefix(ctx.message))[-1]

--- a/core/persistence.py
+++ b/core/persistence.py
@@ -16,7 +16,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
 import sqlite3
 from os import PathLike
-from typing import Any, Iterable, Optional, Union
+from typing import Any, Iterable, Optional, Tuple, Union
 
 from aiosqlite import Connection
 from aiosqlite.context import contextmanager
@@ -150,17 +150,18 @@ class HighlightConnectionMixin(AsyncDatabaseConnection):
     async def fetch_highlights(self) -> Iterable[sqlite3.Row]:
         return await self.execute_fetchall("SELECT * FROM highlight")
 
-    async def fetch_user_highlights(self, user_id: int) -> tuple[str, ...]:
+    async def fetch_user_highlights(self, user_id: int) -> Tuple[str, ...]:
         rows = await self.execute_fetchall("SELECT query FROM highlight WHERE user_id = ?", (user_id,))
         return tuple(row[0] for row in rows)
 
     async def fetch_user_highlight_count(self, user_id: int) -> int:
         return (await self.execute_fetchone("SELECT COUNT(query) FROM highlight WHERE user_id = ?", (user_id,)))[0]  # type: ignore
 
-    async def fetch_user_highlights_starting_with(self, user_id: int, prefix: str) -> Iterable[sqlite3.Row]:
-        return await self.execute_fetchall(
+    async def fetch_user_highlights_starting_with(self, user_id: int, prefix: str) -> Tuple[str, ...]:
+        rows = await self.execute_fetchall(
             "SELECT query FROM highlight WHERE user_id = ? AND query LIKE ?", (user_id, f"{prefix}%")
         )
+        return tuple(row[0] for row in rows)
 
     async def delete_highlight(self, user_id: int, query: str) -> None:
         await self.execute("DELETE FROM highlight WHERE user_id = ? AND query = ?", (user_id, query))


### PR DESCRIPTION
This PR:
- changes all text commands to [hybrid commands](https://discordpy.readthedocs.io/en/latest/ext/commands/api.html#discord.ext.commands.HybridCommand) with autocomplete suggestions
- adds a `sync` command to synchronise all global application (slash) commands to Discord
- adds the option to quote from a message's context menu
- uses display avatars (possibly server-specific) instead of regular avatars in embeds
- fixes black embed colours if the quoted member has no coloured roles
- fixes `KeyError`s for personal/server quotes
- updates Python to version 3.10
- allows quoting up to 5 messages at once by adding `+<number of extra messages>` after a message ID or link