### PR TITLE
server highlights

### DIFF
--- a/cogs/highlights.py
+++ b/cogs/highlights.py
@@ -114,7 +114,7 @@ class Highlights(commands.Cog):
                     global_overwritten = True
             elif guilds := await con.fetch_user_highlight_guilds(user_id, pattern, exclude_global_guild=True):
                 # Warning about server highlights
-                guilds_str = "\n".join([f"`{gid} : {ctx.bot.get_guild(server.id if server else 0).name}`" for gid in guilds])
+                guilds_str = "\n".join([f"`{guild_id} : {ctx.bot.get_guild(server.id if server else 0).name}`" for guild_id in guilds])
                 await ctx.send(
                     ":x: **Server highlights with the same pattern found:**\n"
                     f"{guilds_str}\n"

--- a/cogs/highlights.py
+++ b/cogs/highlights.py
@@ -23,6 +23,7 @@ from discord import app_commands
 from discord.ext import commands
 
 from bot import QuoteBot
+from core.converters import OptionalCurrentGuild
 from core.message_retrieval import DEFAULT_AVATAR_URL
 from core.persistence import QuoteBotDatabaseConnection
 

--- a/cogs/highlights.py
+++ b/cogs/highlights.py
@@ -38,8 +38,10 @@ def _should_send_highlight(msg: discord.Message, member: discord.Member, query: 
         and msg.channel.permissions_for(member).read_messages
     )
 
+
 def _for_guild_str(guild: discord.Guild) -> str:
     return f"for server `{guild.name} ({guild.id})`"
+
 
 class Highlights(commands.Cog):
     def __init__(self, bot: QuoteBot) -> None:
@@ -114,7 +116,9 @@ class Highlights(commands.Cog):
                     global_overwritten = True
             elif guilds := await con.fetch_user_highlight_guilds(user_id, pattern, exclude_global_guild=True):
                 # Warning about server highlights
-                guilds_str = "\n".join([f"`{guild_id} : {ctx.bot.get_guild(server.id if server else 0).name}`" for guild_id in guilds])
+                guilds_str = "\n".join(
+                    [f"`{guild_id} : {ctx.bot.get_guild(server.id if server else 0).name}`" for guild_id in guilds]
+                )
                 await ctx.send(
                     ":x: **Server highlights with the same pattern found:**\n"
                     f"{guilds_str}\n"
@@ -145,7 +149,9 @@ class Highlights(commands.Cog):
             )
             await ctx.send(embed=embed)
         else:
-            await ctx.send(f":x: **You don't have any Highlights{' for server `{guild.name} ({guild.id})`' if server else ''}.**")
+            await ctx.send(
+                f":x: **You don't have any Highlights{' for server `{guild.name} ({guild.id})`' if server else ''}.**"
+            )
 
     def _hightlight_server_list_formatted(self, highlights: Iterable[tuple[str, int]], ctx: commands.Context) -> str:
         guild_patterns = defaultdict(list)

--- a/cogs/highlights.py
+++ b/cogs/highlights.py
@@ -107,7 +107,7 @@ class Highlights(commands.Cog):
                 await ctx.send(":x: **Highlight limit exceeded.**")
             guild_id = server.id if server else 0
             global_overwritten = False
-            if guild_id:
+            if guild_id != 0:
                 # Remove global highlight
                 if await con.fetch_highlight(user_id, pattern, 0):
                     await con.delete_highlight(user_id, pattern, 0)

--- a/cogs/highlights.py
+++ b/cogs/highlights.py
@@ -62,7 +62,7 @@ class Highlights(commands.Cog):
                 await con.clear_user_highlights(user_id)
             elif not (member := msg.guild.get_member(user_id)):
                 continue
-            elif guild_id > 0 and guild_id != msg.guild.id:
+            elif guild_id != 0 and guild_id != msg.guild.id:
                 continue
             elif user_id not in seen_user_ids and _should_send_highlight(msg, member, query):
                 seen_user_ids.add(user_id)

--- a/cogs/highlights.py
+++ b/cogs/highlights.py
@@ -172,12 +172,12 @@ class Highlights(commands.Cog):
             ][:25]
 
     @commands.hybrid_command(aliases=["hlclear"])
-    async def highlightclear(self, ctx: commands.Context) -> None:
-        """Clear all your Highlights."""
+    async def highlightclear(self, ctx: commands.Context, server: discord.Guild | None = OptionalCurrentGuild) -> None:
+        """Clear all your Highlights on the server (0 = all)."""
         async with self.bot.db_connect() as con:
-            await con.clear_user_highlights(ctx.author.id)
+            await con.clear_user_highlights(ctx.author.id, self._get_guild_id(server))
             await con.commit()
-        await ctx.send(":white_check_mark: **Cleared all your Highlights.**")
+        await ctx.send(f":white_check_mark: **Cleared all your Highlights{self._server_text(server, ' ', '')}.**")
 
 
 async def setup(bot: QuoteBot) -> None:

--- a/cogs/highlights.py
+++ b/cogs/highlights.py
@@ -54,10 +54,12 @@ class Highlights(commands.Cog):
         self, con: QuoteBotDatabaseConnection, msg: discord.Message, highlights: Iterable[sqlite3.Row]
     ) -> None:
         seen_user_ids = set()
-        for user_id, query in highlights:
+        for user_id, query, guild_id in highlights:
             if not self.bot.get_user(user_id):
                 await con.clear_user_highlights(user_id)
             elif not (member := msg.guild.get_member(user_id)):
+                continue
+            elif guild_id > 0 and guild_id != msg.guild.id:
                 continue
             elif user_id not in seen_user_ids and _should_send_highlight(msg, member, query):
                 seen_user_ids.add(user_id)

--- a/core/converters.py
+++ b/core/converters.py
@@ -68,6 +68,7 @@ class GlobalTextChannelOrThreadConverter(commands.IDConverter[TextChannelOrThrea
 
 class OptionalGuildConverter(commands.converter.GuildConverter):
     """A :class:`commands.converter.GuildConverter` returning no guild (None) with "0" or "global" as guild-id input."""
+
     async def convert(self, ctx: commands.Context, argument: str) -> discord.Guild | None:
         if argument.lower() in ("0", "global"):
             return None

--- a/core/converters.py
+++ b/core/converters.py
@@ -64,3 +64,19 @@ class GlobalTextChannelOrThreadConverter(commands.IDConverter[TextChannelOrThrea
             raise ChannelOrThreadNotFound(argument)
 
         return result
+
+
+class OptionalGuildConverter(commands.converter.GuildConverter):
+    """A :class:`commands.converter.GuildConverter` returning no guild (None) with "0" or "global" as guild-id input."""
+    async def convert(self, ctx: commands.Context, argument: str) -> discord.Guild | None:
+        if argument.lower() in ("0", "global"):
+            return None
+        return await super().convert(ctx, argument)
+
+
+OptionalCurrentGuild = commands.parameter(
+    default=lambda ctx: ctx.guild,
+    displayed_default="<this server>",
+    converter=OptionalGuildConverter,
+)
+"""`commands.CurrentGuild` with :class:`OptionalGuildConverter`, returning None without a current guild."""

--- a/core/persistence.py
+++ b/core/persistence.py
@@ -191,7 +191,7 @@ class HighlightConnectionMixin(AsyncDatabaseConnection):
     async def fetch_user_highlights_starting_with(
         self, user_id: int, prefix: str, guild_id: int = 0
     ) -> tuple[tuple[str, int], ...]:
-        if guild_id:
+        if guild_id != 0:
             rows = await self.execute_fetchall(
                 "SELECT query, guild_id FROM highlight WHERE user_id = ? AND (guild_id = ? OR guild_id = 0) AND query LIKE ?",
                 (user_id, guild_id, f"{prefix}%"),

--- a/core/persistence.py
+++ b/core/persistence.py
@@ -151,13 +151,13 @@ class HighlightConnectionMixin(AsyncDatabaseConnection):
 
     async def fetch_highlights(self, guild_id: int = 0) -> Iterable[sqlite3.Row]:
         if guild_id:
-            return await self.execute_fetchall("SELECT * FROM highlight WHERE guild_id = ?", (guild_id))
+            return await self.execute_fetchall("SELECT * FROM highlight WHERE (guild_id = ? OR guild_id = 0)", (guild_id))
         return await self.execute_fetchall("SELECT * FROM highlight")
 
     async def fetch_user_highlights(self, user_id: int, guild_id: int = 0) -> Tuple[Tuple[str, int], ...]:
         if guild_id:
             rows = await self.execute_fetchall(
-                "SELECT query, guild_id FROM highlight WHERE user_id = ? AND guild_id = ?", (user_id, guild_id)
+                "SELECT query, guild_id FROM highlight WHERE user_id = ? AND (guild_id = ? OR guild_id = 0)", (user_id, guild_id)
             )
         else:
             rows = await self.execute_fetchall("SELECT query, guild_id FROM highlight WHERE user_id = ?", (user_id,))
@@ -171,7 +171,7 @@ class HighlightConnectionMixin(AsyncDatabaseConnection):
     ) -> Tuple[Tuple[str, int], ...]:
         if guild_id:
             rows = await self.execute_fetchall(
-                "SELECT query, guild_id FROM highlight WHERE user_id = ? AND guild_id = ? AND query LIKE ?",
+                "SELECT query, guild_id FROM highlight WHERE user_id = ? AND (guild_id = ? OR guild_id = 0) AND query LIKE ?",
                 (user_id, guild_id, f"{prefix}%"),
             )
         else:

--- a/core/persistence.py
+++ b/core/persistence.py
@@ -141,8 +141,8 @@ class BlockedConnectionMixin(AsyncDatabaseConnection):
 
 
 class HighlightConnectionMixin(AsyncDatabaseConnection):
-    async def insert_highlight(self, user_id: int, query: str) -> None:
-        await self.execute("INSERT OR IGNORE INTO highlight VALUES (?, ?)", (user_id, query))
+    async def insert_highlight(self, user_id: int, query: str, guild_id: int = 0) -> None:
+        await self.execute("INSERT OR IGNORE INTO highlight VALUES (?, ?, ?)", (user_id, query, guild_id))
 
     async def fetch_highlight(self, user_id: int, query: str) -> Optional[sqlite3.Row]:
         return await self.execute_fetchone("SELECT * FROM highlight WHERE user_id = ? AND query = ?", (user_id, query))

--- a/core/persistence.py
+++ b/core/persistence.py
@@ -149,7 +149,9 @@ class HighlightConnectionMixin(AsyncDatabaseConnection):
             "SELECT * FROM highlight WHERE user_id = ? AND query = ? AND guild_id = ?", (user_id, query, guild_id)
         )
 
-    async def fetch_highlights(self) -> Iterable[sqlite3.Row]:
+    async def fetch_highlights(self, guild_id: int = 0) -> Iterable[sqlite3.Row]:
+        if guild_id:
+            return await self.execute_fetchall("SELECT * FROM highlight WHERE guild_id = ?", (guild_id))
         return await self.execute_fetchall("SELECT * FROM highlight")
 
     async def fetch_user_highlights(self, user_id: int, guild_id: int = 0) -> Tuple[Tuple[str, int], ...]:
@@ -186,8 +188,11 @@ class HighlightConnectionMixin(AsyncDatabaseConnection):
         else:
             await self.execute("DELETE FROM highlight WHERE user_id = ? AND query = ?", (user_id, query))
 
-    async def clear_user_highlights(self, user_id: int) -> None:
-        await self.execute("DELETE FROM highlight WHERE user_id = ?", (user_id,))
+    async def clear_user_highlights(self, user_id: int, guild_id: int = 0) -> None:
+        if guild_id:
+            await self.execute("DELETE FROM highlight WHERE user_id = ? AND guild_id = ?", (user_id, guild_id))
+        else:
+            await self.execute("DELETE FROM highlight WHERE user_id = ?", (user_id,))
 
 
 class SavedQuoteConnectionMixin(AsyncDatabaseConnection):

--- a/core/persistence.py
+++ b/core/persistence.py
@@ -211,7 +211,7 @@ class HighlightConnectionMixin(AsyncDatabaseConnection):
             await self.execute("DELETE FROM highlight WHERE user_id = ? AND query = ?", (user_id, query))
 
     async def clear_user_highlights(self, user_id: int, guild_id: int = 0) -> None:
-        if guild_id:
+        if guild_id != 0:
             await self.execute("DELETE FROM highlight WHERE user_id = ? AND guild_id = ?", (user_id, guild_id))
         else:
             await self.execute("DELETE FROM highlight WHERE user_id = ?", (user_id,))

--- a/core/persistence.py
+++ b/core/persistence.py
@@ -246,7 +246,8 @@ class QuoteBotDatabaseConnection(
             IF NOT EXISTS highlight (
                 user_id INTEGER NOT NULL,
                 query TEXT NOT NULL,
-                PRIMARY KEY (user_id, query)
+                guild_id INTEGER NOT NULL DEFAULT 0,
+                PRIMARY KEY (user_id, query, guild_id)
             );
             CREATE TABLE
             IF NOT EXISTS blocked (
@@ -259,6 +260,14 @@ class QuoteBotDatabaseConnection(
             BEGIN
                 DELETE FROM saved_quote
                 WHERE owner_id = old.guild_id;
+            END;
+
+            CREATE TRIGGER
+            IF NOT EXISTS delete_guild_highlights
+                AFTER DELETE ON guild
+            BEGIN
+                DELETE FROM highlight
+                WHERE guild_id = old.guild_id;
             END;
         """
         )

--- a/core/persistence.py
+++ b/core/persistence.py
@@ -150,9 +150,14 @@ class HighlightConnectionMixin(AsyncDatabaseConnection):
     async def fetch_highlights(self) -> Iterable[sqlite3.Row]:
         return await self.execute_fetchall("SELECT * FROM highlight")
 
-    async def fetch_user_highlights(self, user_id: int) -> Tuple[str, ...]:
-        rows = await self.execute_fetchall("SELECT query FROM highlight WHERE user_id = ?", (user_id,))
-        return tuple(row[0] for row in rows)
+    async def fetch_user_highlights(self, user_id: int, guild_id: int = 0) -> Tuple[Tuple[str, int], ...]:
+        if guild_id:
+            rows = await self.execute_fetchall(
+                "SELECT query, guild_id FROM highlight WHERE user_id = ? AND guild_id = ?", (user_id, guild_id)
+            )
+        else:
+            rows = await self.execute_fetchall("SELECT query, guild_id FROM highlight WHERE user_id = ?", (user_id,))
+        return tuple(tuple(row) for row in rows)
 
     async def fetch_user_highlight_count(self, user_id: int) -> int:
         return (await self.execute_fetchone("SELECT COUNT(query) FROM highlight WHERE user_id = ?", (user_id,)))[0]  # type: ignore

--- a/core/persistence.py
+++ b/core/persistence.py
@@ -159,8 +159,8 @@ class HighlightConnectionMixin(AsyncDatabaseConnection):
         self, user_id: int, guild_id: int = 0, order_by_guild=False
     ) -> tuple[tuple[str, int], ...]:
         """All relevant guilds included:
-            `guild_id = 0` includes all guilds,
-            `guild_id != 0` includes the global guilds (0).
+        `guild_id = 0` includes all guilds,
+        `guild_id != 0` includes the global guilds (0).
         """
         return tuple(
             (row["query"], row["guild_id"])


### PR DESCRIPTION
Server specific highlights, with the current server as default (global on 0 or DM):
`>[highlight|hl|hladd] <pattern> [server=<this server>]`

Other highlight commands changed accordingly.

Update script for db: [upgrade_db.py](https://github.com/ZashIn/QuoteBot/blob/feat/server-highlight-upgrade/upgrade_db.py)

### TODO
- [x] same pattern overwriting global <-> local.